### PR TITLE
Support for more native event types to Windows services

### DIFF
--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -56,9 +56,30 @@ const (
 type Accepted uint32
 
 const (
-	AcceptStop             = Accepted(windows.SERVICE_ACCEPT_STOP)
-	AcceptShutdown         = Accepted(windows.SERVICE_ACCEPT_SHUTDOWN)
-	AcceptPauseAndContinue = Accepted(windows.SERVICE_ACCEPT_PAUSE_CONTINUE)
+	AcceptStop                  = Accepted(windows.SERVICE_ACCEPT_STOP)
+	AcceptShutdown              = Accepted(windows.SERVICE_ACCEPT_SHUTDOWN)
+	AcceptPauseAndContinue      = Accepted(windows.SERVICE_ACCEPT_PAUSE_CONTINUE)
+	AcceptParamChange           = Accepted(windows.SERVICE_ACCEPT_PARAMCHANGE)
+	AcceptNetBindChange         = Accepted(windows.SERVICE_ACCEPT_NETBINDCHANGE)
+	AcceptHardwareProfileChange = Accepted(windows.SERVICE_ACCEPT_HARDWAREPROFILECHANGE)
+	AcceptPowerEvent            = Accepted(windows.SERVICE_ACCEPT_POWEREVENT)
+	AcceptSessionChange         = Accepted(windows.SERVICE_ACCEPT_SESSIONCHANGE)
+)
+
+const (
+	PowerQuerySuspend uint32 = iota // You can object to this
+	PowerQueryStandby
+	PowerQuerySuspendFailed
+	PowerQueryStandbyFailed
+	PowerSuspend // Going to sleep
+	PowerStandby // Going to suspend
+	PowerResumeCritical
+	PowerResumeSuspend // Waking up, you can resume interaction with user
+	PowerResumeStandby
+	PowerBatteryLow
+	PowerStatusChange
+	PowerOEMEvent
+	PowerResumeAutomatic = 18 // Waking up
 )
 
 // Status combines State and Accepted commands to fully describe running service.
@@ -180,6 +201,22 @@ func (s *service) updateStatus(status *Status, ec *exitCode) error {
 	if status.Accepts&AcceptPauseAndContinue != 0 {
 		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PAUSE_CONTINUE
 	}
+	if status.Accepts&AcceptParamChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PARAMCHANGE
+	}
+	if status.Accepts&AcceptNetBindChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_NETBINDCHANGE
+	}
+	if status.Accepts&AcceptHardwareProfileChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_HARDWAREPROFILECHANGE
+	}
+	if status.Accepts&AcceptPowerEvent != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_POWEREVENT
+	}
+	if status.Accepts&AcceptSessionChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_SESSIONCHANGE
+	}
+
 	if ec.errno == 0 {
 		t.Win32ExitCode = windows.NO_ERROR
 		t.ServiceSpecificExitCode = windows.NO_ERROR


### PR DESCRIPTION
I needed to be notified for power events for a Windows service I'm doing. I added the missing defines for that. I haven't tested it with the other event types.