### PR TITLE
unix: use /proc/self/exe instead of os.Args[0] in test.

### DIFF
--- a/unix/syscall_unix_test.go
+++ b/unix/syscall_unix_test.go
@@ -108,7 +108,7 @@ func TestPassFD(t *testing.T) {
 	defer writeFile.Close()
 	defer readFile.Close()
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestPassFD$", "--", tempDir)
+	cmd := exec.Command("/proc/self/exe", "-test.run=^TestPassFD$", "--", tempDir)
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
 	if lp := os.Getenv("LD_LIBRARY_PATH"); lp != "" {
 		cmd.Env = append(cmd.Env, "LD_LIBRARY_PATH="+lp)


### PR DESCRIPTION
If these tests happen to be run out of order, TestGetwd can be run before TestPassFD. TestGetwd changes the cwd, so os.Args[0] is potentially not relative to the right directory anymore.

(cc: googlers, this is so I can import a new version of x/sys/unix to g3.)