### PR TITLE
unix: add S_IRWXG and S_IRWXO to FreeBSD types

### DIFF
--- a/unix/types_freebsd.go
+++ b/unix/types_freebsd.go
@@ -204,6 +204,8 @@ const ( // Directory mode bits
 	S_IRUSR  = C.S_IRUSR
 	S_IWUSR  = C.S_IWUSR
 	S_IXUSR  = C.S_IXUSR
+	S_IRWXG  = C.S_IRWXG
+	S_IRWXO  = C.S_IRWXO
 )
 
 type Stat_t C.struct_stat8

--- a/unix/ztypes_freebsd_386.go
+++ b/unix/ztypes_freebsd_386.go
@@ -71,6 +71,8 @@ const (
 	S_IRUSR  = 0x100
 	S_IWUSR  = 0x80
 	S_IXUSR  = 0x40
+	S_IRWXG  = 0x38
+	S_IRWXO  = 0x7
 )
 
 type Stat_t struct {

--- a/unix/ztypes_freebsd_amd64.go
+++ b/unix/ztypes_freebsd_amd64.go
@@ -71,6 +71,8 @@ const (
 	S_IRUSR  = 0x100
 	S_IWUSR  = 0x80
 	S_IXUSR  = 0x40
+	S_IRWXG  = 0x38
+	S_IRWXO  = 0x7
 )
 
 type Stat_t struct {

--- a/unix/ztypes_freebsd_arm.go
+++ b/unix/ztypes_freebsd_arm.go
@@ -73,6 +73,8 @@ const (
 	S_IRUSR  = 0x100
 	S_IWUSR  = 0x80
 	S_IXUSR  = 0x40
+	S_IRWXG  = 0x38
+	S_IRWXO  = 0x7
 )
 
 type Stat_t struct {


### PR DESCRIPTION
I found this during https://github.com/DataDog/datadog-agent/pull/2079