### PR TITLE
windows: correct misspelling in comment

### DIFF
--- a/windows/types_windows.go
+++ b/windows/types_windows.go
@@ -1453,7 +1453,7 @@ type SmallRect struct {
 	Bottom int16
 }
 
-// Used with GetConsoleScreenBuffer to retreive information about a console
+// Used with GetConsoleScreenBuffer to retrieve information about a console
 // screen buffer. See
 // https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str
 // for details.


### PR DESCRIPTION
The comment for ConsoleScreenBufferInfo uses the word 'retreive' that
is a misspelling of 'retrieve'.
