### PR TITLE
unix: add sockaddr and defines for PPPoE sockets.

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -48,6 +48,7 @@ package unix
 #include <sys/wait.h>
 #include <linux/filter.h>
 #include <linux/icmpv6.h>
+#include <linux/if_pppox.h>
 #include <linux/keyctl.h>
 #include <linux/netfilter/nf_tables.h>
 #include <linux/netfilter/nfnetlink.h>
@@ -168,6 +169,7 @@ union sockaddr_all {
 	struct sockaddr_un s4;
 	struct sockaddr_ll s5;
 	struct sockaddr_nl s6;
+	struct sockaddr_pppox s7;
 };
 
 struct sockaddr_any {
@@ -432,6 +434,8 @@ type RawSockaddrVM C.struct_sockaddr_vm
 
 type RawSockaddrXDP C.struct_sockaddr_xdp
 
+type RawSockaddrPPPoX [C.sizeof_struct_sockaddr_pppox]byte
+
 type RawSockaddr C.struct_sockaddr
 
 type RawSockaddrAny C.struct_sockaddr_any
@@ -480,6 +484,7 @@ const (
 	SizeofSockaddrALG       = C.sizeof_struct_sockaddr_alg
 	SizeofSockaddrVM        = C.sizeof_struct_sockaddr_vm
 	SizeofSockaddrXDP       = C.sizeof_struct_sockaddr_xdp
+	SizeofSockaddrPPPoX     = C.sizeof_struct_sockaddr_pppox
 	SizeofLinger            = C.sizeof_struct_linger
 	SizeofIovec             = C.sizeof_struct_iovec
 	SizeofIPMreq            = C.sizeof_struct_ip_mreq

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -13,7 +13,6 @@ package unix
 
 import (
 	"encoding/binary"
-	"errors"
 	"net"
 	"syscall"
 	"unsafe"
@@ -871,7 +870,7 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 	case AF_PPPOX:
 		pp := (*RawSockaddrPPPoX)(unsafe.Pointer(rsa))
 		if binary.BigEndian.Uint32(pp[2:6]) != px_proto_oe {
-			return nil, errors.New("PPPOX address type is not PPPoE")
+			return nil, EINVAL
 		}
 		sa := &SockaddrPPPoE{
 			SID:    binary.BigEndian.Uint16(pp[6:8]),

--- a/unix/ztypes_linux_386.go
+++ b/unix/ztypes_linux_386.go
@@ -286,6 +286,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -421,6 +423,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x8
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_amd64.go
+++ b/unix/ztypes_linux_amd64.go
@@ -288,6 +288,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -425,6 +427,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_arm.go
+++ b/unix/ztypes_linux_arm.go
@@ -289,6 +289,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]uint8
@@ -424,6 +426,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x8
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_arm64.go
+++ b/unix/ztypes_linux_arm64.go
@@ -289,6 +289,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -426,6 +428,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_mips.go
+++ b/unix/ztypes_linux_mips.go
@@ -287,6 +287,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -422,6 +424,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x8
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_mips64.go
+++ b/unix/ztypes_linux_mips64.go
@@ -289,6 +289,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -426,6 +428,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_mips64le.go
+++ b/unix/ztypes_linux_mips64le.go
@@ -289,6 +289,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -426,6 +428,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_mipsle.go
+++ b/unix/ztypes_linux_mipsle.go
@@ -287,6 +287,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -422,6 +424,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x8
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_ppc64.go
+++ b/unix/ztypes_linux_ppc64.go
@@ -290,6 +290,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]uint8
@@ -427,6 +429,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_ppc64le.go
+++ b/unix/ztypes_linux_ppc64le.go
@@ -290,6 +290,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]uint8
@@ -427,6 +429,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_riscv64.go
+++ b/unix/ztypes_linux_riscv64.go
@@ -289,6 +289,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]uint8
@@ -426,6 +428,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8

--- a/unix/ztypes_linux_s390x.go
+++ b/unix/ztypes_linux_s390x.go
@@ -288,6 +288,8 @@ type RawSockaddrXDP struct {
 	Shared_umem_fd uint32
 }
 
+type RawSockaddrPPPoX [0x1e]byte
+
 type RawSockaddr struct {
 	Family uint16
 	Data   [14]int8
@@ -425,6 +427,7 @@ const (
 	SizeofSockaddrALG       = 0x58
 	SizeofSockaddrVM        = 0x10
 	SizeofSockaddrXDP       = 0x10
+	SizeofSockaddrPPPoX     = 0x1e
 	SizeofLinger            = 0x8
 	SizeofIovec             = 0x10
 	SizeofIPMreq            = 0x8


### PR DESCRIPTION
`sockaddr_pppox` is a packed struct, which godefs doesn't understand.
So, I had to do the byte packing by hand instead.