### PR TITLE
unix: add IoctlSetPointerInt

### DIFF
--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -57,6 +57,15 @@ func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
 // ioctl itself should not be exposed directly, but additional get/set
 // functions for specific types are permissible.
 
+// IoctlSetPointerInt performs an ioctl operation which sets an
+// integer value on fd, using the specified request number. The ioctl
+// argument is called with a pointer to the integer value, rather than
+// passing the integer value directly.
+func IoctlSetPointerInt(fd int, req uint, value int) error {
+	v := int32(value)
+	return ioctl(fd, req, uintptr(unsafe.Pointer(&v)))
+}
+
 // IoctlSetInt performs an ioctl operation which sets an integer value
 // on fd, using the specified request number.
 func IoctlSetInt(fd int, req uint, value int) error {


### PR DESCRIPTION
IoctlSetPointerInt is necessary for interacting with the PPP kernel
driver, which wants it passed as a pointer to int, rather than the
more conventional int cast as a pointer.

We can technically do this already with
IoctlSetInt(int(uintptr(unsafe.Pointer(&foo)))), but that's just
masking the operation we're trying to execute in the first place,
and relying on the internals of IoctlSetInt to do the right
inverse transformation.
