### PR TITLE
unix: fix unused import in syscall_darwin_386.go

### DIFF
--- a/unix/syscall_darwin_386.go
+++ b/unix/syscall_darwin_386.go
@@ -8,7 +8,6 @@ package unix
 
 import (
 	"syscall"
-	"unsafe"
 )
 
 func setTimespec(sec, nsec int64) Timespec {


### PR DESCRIPTION
Fix a compile error due to unused import introduced by CL 154663.