### PR TITLE
unix: mksysnum: correct +build restriction

### DIFF
--- a/unix/mksysnum.go
+++ b/unix/mksysnum.go
@@ -1,13 +1,13 @@
 // Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-//
+
+// +build ignore
+
 // Generate system call table for DragonFly, NetBSD,
 // FreeBSD, OpenBSD or Darwin from master list
 // (for example, /usr/src/sys/kern/syscalls.master or
 // sys/syscall.h).
-
-// +build ignore
 package main
 
 import (


### PR DESCRIPTION
Previously the +build line was taken as a package comment, due to how Go
handles cases like the following:

  // +build <foo>
  package foo

And thus caused build failures because of package name conflict issues.

Fixes: https://golang.org/cl/152677