### PR TITLE
mkerrors: Replace wrong include with correct one

### DIFF
--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -43,9 +43,9 @@ includes_AIX='
 #include <sys/protosw.h>
 #include <sys/stropts.h>
 #include <sys/mman.h>
-#include <sys/poll.h>
 #include <sys/termio.h>
 #include <termios.h>
+#include <poll.h>
 #include <fcntl.h>
 
 #define AF_LOCAL AF_UNIX


### PR DESCRIPTION
Fixes:

#warning redirecting incorrect #include <sys/poll.h> to <poll.h>

Under Musl.