### PR TITLE
add AmcTime get last access,modify,change time

### DIFF
--- a/unix/ztypes_aix_ppc.go
+++ b/unix/ztypes_aix_ppc.go
@@ -113,6 +113,18 @@ type Stat_t struct {
 	Reserved [9]uint32
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	atim.Sec = s.Atim.Sec
+	atim.Nsec = s.Atim.Nsec
+
+	mtim.Sec = s.Mtim.Sec
+	mtim.Nsec = s.Mtim.Nsec
+
+	ctim.Sec = s.Ctim.Sec
+	ctim.Nsec = s.Ctim.Nsec
+	return
+}
+
 type StatxTimestamp struct{}
 
 type Statx_t struct{}

--- a/unix/ztypes_aix_ppc64.go
+++ b/unix/ztypes_aix_ppc64.go
@@ -117,6 +117,18 @@ type Stat_t struct {
 	Size     int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	atim.Sec = s.Atim.Sec
+	atim.Nsec = s.Atim.Nsec
+
+	mtim.Sec = s.Mtim.Sec
+	mtim.Nsec = s.Mtim.Nsec
+
+	ctim.Sec = s.Ctim.Sec
+	ctim.Nsec = s.Ctim.Nsec
+	return
+}
+
 type StatxTimestamp struct{}
 
 type Statx_t struct{}

--- a/unix/ztypes_darwin_386.go
+++ b/unix/ztypes_darwin_386.go
@@ -79,6 +79,10 @@ type Stat_t struct {
 	Qspare        [2]int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t struct {
 	Bsize       uint32
 	Iosize      int32

--- a/unix/ztypes_darwin_amd64.go
+++ b/unix/ztypes_darwin_amd64.go
@@ -84,6 +84,10 @@ type Stat_t struct {
 	Qspare        [2]int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t struct {
 	Bsize       uint32
 	Iosize      int32

--- a/unix/ztypes_darwin_arm.go
+++ b/unix/ztypes_darwin_arm.go
@@ -80,6 +80,10 @@ type Stat_t struct {
 	Qspare        [2]int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t struct {
 	Bsize       uint32
 	Iosize      int32

--- a/unix/ztypes_darwin_arm64.go
+++ b/unix/ztypes_darwin_arm64.go
@@ -84,6 +84,10 @@ type Stat_t struct {
 	Qspare        [2]int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t struct {
 	Bsize       uint32
 	Iosize      int32

--- a/unix/ztypes_dragonfly_amd64.go
+++ b/unix/ztypes_dragonfly_amd64.go
@@ -78,6 +78,10 @@ type Stat_t struct {
 	Qspare2  int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type Statfs_t struct {
 	Spare2      int64
 	Bsize       int64

--- a/unix/ztypes_freebsd_386.go
+++ b/unix/ztypes_freebsd_386.go
@@ -87,6 +87,10 @@ type Stat_t struct {
 	Spare    [10]uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type stat_freebsd11_t struct {
 	Dev      uint32
 	Ino      uint32

--- a/unix/ztypes_freebsd_amd64.go
+++ b/unix/ztypes_freebsd_amd64.go
@@ -83,6 +83,10 @@ type Stat_t struct {
 	Spare    [10]uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type stat_freebsd11_t struct {
 	Dev      uint32
 	Ino      uint32

--- a/unix/ztypes_freebsd_arm.go
+++ b/unix/ztypes_freebsd_arm.go
@@ -85,6 +85,10 @@ type Stat_t struct {
 	Spare    [10]uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type stat_freebsd11_t struct {
 	Dev      uint32
 	Ino      uint32
@@ -103,6 +107,10 @@ type stat_freebsd11_t struct {
 	Gen      uint32
 	Lspare   int32
 	Birthtim Timespec
+}
+
+func (s *stat_freebsd11_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
 }
 
 type Statfs_t struct {

--- a/unix/ztypes_freebsd_arm64.go
+++ b/unix/ztypes_freebsd_arm64.go
@@ -83,6 +83,10 @@ type Stat_t struct {
 	Spare    [10]uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type stat_freebsd11_t struct {
 	Dev      uint32
 	Ino      uint32

--- a/unix/ztypes_linux_386.go
+++ b/unix/ztypes_linux_386.go
@@ -114,6 +114,10 @@ type Stat_t struct {
 	Ino     uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_amd64.go
+++ b/unix/ztypes_linux_amd64.go
@@ -113,6 +113,10 @@ type Stat_t struct {
 	_       [3]int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_arm.go
+++ b/unix/ztypes_linux_arm.go
@@ -116,6 +116,10 @@ type Stat_t struct {
 	Ino     uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_arm64.go
+++ b/unix/ztypes_linux_arm64.go
@@ -114,6 +114,10 @@ type Stat_t struct {
 	_       [2]int32
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_mips.go
+++ b/unix/ztypes_linux_mips.go
@@ -115,6 +115,10 @@ type Stat_t struct {
 	Pad5    [14]int32
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_mips64.go
+++ b/unix/ztypes_linux_mips64.go
@@ -114,6 +114,10 @@ type Stat_t struct {
 	Blocks  int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_mips64le.go
+++ b/unix/ztypes_linux_mips64le.go
@@ -114,6 +114,10 @@ type Stat_t struct {
 	Blocks  int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_mipsle.go
+++ b/unix/ztypes_linux_mipsle.go
@@ -115,6 +115,10 @@ type Stat_t struct {
 	Pad5    [14]int32
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_ppc64.go
+++ b/unix/ztypes_linux_ppc64.go
@@ -115,6 +115,10 @@ type Stat_t struct {
 	_       uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_ppc64le.go
+++ b/unix/ztypes_linux_ppc64le.go
@@ -115,6 +115,10 @@ type Stat_t struct {
 	_       uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_riscv64.go
+++ b/unix/ztypes_linux_riscv64.go
@@ -114,6 +114,10 @@ type Stat_t struct {
 	_       [2]int32
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_s390x.go
+++ b/unix/ztypes_linux_s390x.go
@@ -113,6 +113,10 @@ type Stat_t struct {
 	_       [3]int64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_linux_sparc64.go
+++ b/unix/ztypes_linux_sparc64.go
@@ -116,6 +116,10 @@ type Stat_t struct {
 	_       uint64
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type StatxTimestamp struct {
 	Sec  int64
 	Nsec uint32

--- a/unix/ztypes_netbsd_386.go
+++ b/unix/ztypes_netbsd_386.go
@@ -76,6 +76,10 @@ type Stat_t struct {
 	Spare         [2]uint32
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t [0]byte
 
 type Flock_t struct {

--- a/unix/ztypes_netbsd_amd64.go
+++ b/unix/ztypes_netbsd_amd64.go
@@ -80,6 +80,10 @@ type Stat_t struct {
 	Pad_cgo_2     [4]byte
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t [0]byte
 
 type Flock_t struct {

--- a/unix/ztypes_netbsd_arm.go
+++ b/unix/ztypes_netbsd_arm.go
@@ -81,6 +81,10 @@ type Stat_t struct {
 	Pad_cgo_2     [4]byte
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t [0]byte
 
 type Flock_t struct {

--- a/unix/ztypes_netbsd_arm64.go
+++ b/unix/ztypes_netbsd_arm64.go
@@ -80,6 +80,10 @@ type Stat_t struct {
 	Pad_cgo_2     [4]byte
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atimespec, s.Mtimespec, s.Ctimespec
+}
+
 type Statfs_t [0]byte
 
 type Flock_t struct {

--- a/unix/ztypes_openbsd_386.go
+++ b/unix/ztypes_openbsd_386.go
@@ -75,6 +75,10 @@ type Stat_t struct {
 	X__st_birthtim Timespec
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type Statfs_t struct {
 	F_flags       uint32
 	F_bsize       uint32

--- a/unix/ztypes_openbsd_amd64.go
+++ b/unix/ztypes_openbsd_amd64.go
@@ -76,6 +76,10 @@ type Stat_t struct {
 	_       Timespec
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type Statfs_t struct {
 	F_flags       uint32
 	F_bsize       uint32

--- a/unix/ztypes_openbsd_arm.go
+++ b/unix/ztypes_openbsd_arm.go
@@ -78,6 +78,10 @@ type Stat_t struct {
 	_       Timespec
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type Statfs_t struct {
 	F_flags       uint32
 	F_bsize       uint32

--- a/unix/ztypes_openbsd_arm64.go
+++ b/unix/ztypes_openbsd_arm64.go
@@ -75,6 +75,10 @@ type Stat_t struct {
 	_       Timespec
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type Statfs_t struct {
 	F_flags       uint32
 	F_bsize       uint32

--- a/unix/ztypes_solaris_amd64.go
+++ b/unix/ztypes_solaris_amd64.go
@@ -93,6 +93,10 @@ type Stat_t struct {
 	Fstype  [16]int8
 }
 
+func (s *Stat_t) AmcTime() (atim, mtim, ctim Timespec) {
+	return s.Atim, s.Mtim, s.Ctim
+}
+
 type Flock_t struct {
 	Type   int16
 	Whence int16


### PR DESCRIPTION
fix https://github.com/golang/go/issues/31735

Add Time to last access, Time of last modification, Time of last status change to add AmcTime accessor

My test code
```
env GOPATH=`pwd` go run test.go < stat_t.list
```
test.go
``` go
package main

import (
    "bufio"
    "bytes"
    "fmt"
    "os"
    "os/exec"
)

func main() {
    br := bufio.NewReader(os.Stdin)

    for {

        l, e := br.ReadBytes('\n')
        if e != nil && len(l) == 0 { 
            break
        }

        s := bytes.Split(l, []byte("_"))
        if len(s) != 3 { 
            continue
        }

        if pos := bytes.LastIndex(s[2], []byte(".")); pos != -1 {
            s[2] = s[2][:pos]
        }

        testCmd := fmt.Sprintf("env GOPATH=`pwd` CGO_ENABLED=0 GOOS=%s GOARCH=%s go build sys.go", s[1], s[2])

        cmd := exec.Command("bash", "-c", testCmd)
        _, err := cmd.Output()
        if err != nil {
            fmt.Printf("err = %s, cmd(%s)\n", err, testCmd)
        }
    }
}
```
stat_t.list
```
cat stat_t.list 
ztypes_aix_ppc64.go
ztypes_aix_ppc.go
ztypes_darwin_386.go
ztypes_darwin_amd64.go
ztypes_darwin_arm64.go
ztypes_darwin_arm.go
ztypes_dragonfly_amd64.go
ztypes_freebsd_386.go
ztypes_freebsd_amd64.go
ztypes_freebsd_arm64.go
ztypes_freebsd_arm.go
ztypes_linux_386.go
ztypes_linux_amd64.go
ztypes_linux_arm64.go
ztypes_linux_arm.go
ztypes_linux_mips64.go
ztypes_linux_mips64le.go
ztypes_linux_mips.go
ztypes_linux_mipsle.go
ztypes_linux_ppc64.go
ztypes_linux_ppc64le.go
ztypes_linux_riscv64.go
ztypes_linux_s390x.go
ztypes_linux_sparc64.go
ztypes_netbsd_386.go
ztypes_netbsd_amd64.go
ztypes_netbsd_arm64.go
ztypes_netbsd_arm.go
ztypes_openbsd_386.go
ztypes_openbsd_amd64.go
ztypes_openbsd_arm64.go
ztypes_openbsd_arm.go
ztypes_solaris_amd64.go

```
Stat_t.txt is generated by the following code
``` bash
cd src/golang.org/x/sys/unix
grep 'type Stat_t struct' -r -l|sort -u &>/tmp/stat_t.list
```
sys.go
``` go
package main

import (
	"fmt"
	"golang.org/x/sys/unix"
	"os"
	"time"
)

func statTimes(name string) (atime, mtime, ctime time.Time, err error) {
	var stat unix.Stat_t
	err = unix.Stat(name, &stat)
	if err != nil {
		return
	}

	atime1, mtime1, ctime1 := stat.AmcTime()
	//fmt.Println(stat.AmcTime())
	atime = time.Unix(int64(atime1.Sec), int64(atime1.Nsec))
	mtime = time.Unix(int64(mtime1.Sec), int64(mtime1.Nsec))
	ctime = time.Unix(int64(ctime1.Sec), int64(ctime1.Nsec))
	return
}

func main() {

	fmt.Println(statTimes(os.Args[0]))
}

```