### PR TITLE
windows: add CTRL_CLOSE_EVENT, CTRL_LOGOFF_EVENT, and CTRL_SHUTDOWN_EVENT

### DIFF
--- a/windows/types_windows.go
+++ b/windows/types_windows.go
@@ -197,8 +197,11 @@ const (
 	FILE_MAP_READ    = 0x04
 	FILE_MAP_EXECUTE = 0x20
 
-	CTRL_C_EVENT     = 0
-	CTRL_BREAK_EVENT = 1
+	CTRL_C_EVENT        = 0
+	CTRL_BREAK_EVENT    = 1
+	CTRL_CLOSE_EVENT    = 2
+	CTRL_LOGOFF_EVENT   = 5
+	CTRL_SHUTDOWN_EVENT = 6
 
 	// Windows reserves errors >= 1<<29 for application use.
 	APPLICATION_ERROR = 1 << 29


### PR DESCRIPTION
This is part of the changes necessary to allow simulated `SIGTERM` on Windows (these are the relevant events for `SetConsoleCtrlHandler` that would correspond to `SIGTERM` on Unix).

See https://docs.microsoft.com/en-us/windows/console/handlerroutine for a good documentation source upstream to confirm these values.

Updates golang/go#7479

(This exists under `src/cmd/vendor/golang.org/x/sys/windows/types_windows.go` in https://github.com/golang/go, so I figured I would start here and follow up with a https://github.com/golang/go PR/CL if reviewers here were amenable to this half.)