### PR TITLE
unix: add riscv64 tag to endian_little.go

### DIFF
--- a/unix/endian_little.go
+++ b/unix/endian_little.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //
-// +build 386 amd64 amd64p32 arm arm64 ppc64le mipsle mips64le
+// +build 386 amd64 amd64p32 arm arm64 ppc64le mipsle mips64le riscv64
 
 package unix
 


### PR DESCRIPTION
Update golang/go#27532 