### PR TITLE
unix: add new func PtraceSeize on Linux

### DIFF
--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -1495,6 +1495,8 @@ func PtraceSingleStep(pid int) (err error) { return ptrace(PTRACE_SINGLESTEP, pi
 
 func PtraceAttach(pid int) (err error) { return ptrace(PTRACE_ATTACH, pid, 0, 0) }
 
+func PtraceSeize(pid int) (err error) { return ptrace(PTRACE_SEIZE, pid, 0, 0) }
+
 func PtraceDetach(pid int) (err error) { return ptrace(PTRACE_DETACH, pid, 0, 0) }
 
 //sys	reboot(magic1 uint, magic2 uint, cmd int, arg string) (err error)


### PR DESCRIPTION
Add to the unix package a new func to allow ptrace using PTRACE_SEIZE.

Fixes golang/go#34717