### PR TITLE
unix: add new func PtraceInterrupt on Linux

### DIFF
--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -1493,6 +1493,8 @@ func PtraceSyscall(pid int, signal int) (err error) {
 
 func PtraceSingleStep(pid int) (err error) { return ptrace(PTRACE_SINGLESTEP, pid, 0, 0) }
 
+func PtraceInterrupt(pid int) (err error) { return ptrace(PTRACE_INTERRUPT, pid, 0, 0) }
+
 func PtraceAttach(pid int) (err error) { return ptrace(PTRACE_ATTACH, pid, 0, 0) }
 
 func PtraceSeize(pid int) (err error) { return ptrace(PTRACE_SEIZE, pid, 0, 0) }


### PR DESCRIPTION
Add to the unix package a new func to allow ptrace using PTRACE_INTERRUPT.

Fixes golang/go#34755