### PR TITLE
x/sys/unix: add PrctlRetInt, a Prctl variant that returns (int, error)

### DIFF
--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -1631,6 +1631,17 @@ func Getpgrp() (pid int) {
 //sysnb	Settimeofday(tv *Timeval) (err error)
 //sys	Setns(fd int, nstype int) (err error)
 
+// PrctlRetInt performs a prctl operation specified by option and further
+// optional arguments arg2 through arg5 depending on option. It returns a
+// non-negative integer that is returned by the prctl syscall.
+func PrctlRetInt(option int, arg2 uintptr, arg3 uintptr, arg4 uintptr, arg5 uintptr) (int, error) {
+	ret, _, err := Syscall6(SYS_PRCTL, uintptr(option), uintptr(arg2), uintptr(arg3), uintptr(arg4), uintptr(arg5), 0)
+	if err != 0 {
+		return 0, err
+	}
+	return int(ret), nil
+}
+
 // issue 1435.
 // On linux Setuid and Setgid only affects the current thread, not the process.
 // This does not match what most callers expect so we must return an error

--- a/unix/syscall_linux_test.go
+++ b/unix/syscall_linux_test.go
@@ -686,3 +686,17 @@ func TestEpoll(t *testing.T) {
 		t.Errorf("EpollWait: wrong Fd in event: got %v, expected %v", got, fd)
 	}
 }
+
+func TestPrctlRetInt(t *testing.T) {
+	err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)
+	if err != nil {
+		t.Skipf("Prctl: %v, skipping test", err)
+	}
+	v, err := unix.PrctlRetInt(unix.PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("failed to perform prctl: %v", err)
+	}
+	if v != 1 {
+		t.Fatalf("unexpected return from prctl; got %v, expected %v", v, 1)
+	}
+}


### PR DESCRIPTION
Fixes golang/go#35978