### PR TITLE
windows: fix recvfrom and sendto data types

### DIFF
--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -701,8 +701,8 @@ const socket_error = uintptr(^uint32(0))
 //sys	WSACleanup() (err error) [failretval==socket_error] = ws2_32.WSACleanup
 //sys	WSAIoctl(s Handle, iocc uint32, inbuf *byte, cbif uint32, outbuf *byte, cbob uint32, cbbr *uint32, overlapped *Overlapped, completionRoutine uintptr) (err error) [failretval==socket_error] = ws2_32.WSAIoctl
 //sys	socket(af int32, typ int32, protocol int32) (handle Handle, err error) [failretval==InvalidHandle] = ws2_32.socket
-//sys	sendto(s Handle, buf []byte, flags int, to unsafe.Pointer, tolen int32) (err error) [failretval==socket_error] = ws2_32.sendto
-//sys	recvfrom(s Handle, buf []byte, flags int, from *RawSockaddrAny, fromlen *int) (n int, err error) [failretval==-1] = ws2_32.recvfrom
+//sys	sendto(s Handle, buf []byte, flags int32, to unsafe.Pointer, tolen int32) (err error) [failretval==socket_error] = ws2_32.sendto
+//sys	recvfrom(s Handle, buf []byte, flags int32, from *RawSockaddrAny, fromlen *int32) (n int32, err error) [failretval==-1] = ws2_32.recvfrom
 //sys	Setsockopt(s Handle, level int32, optname int32, optval *byte, optlen int32) (err error) [failretval==socket_error] = ws2_32.setsockopt
 //sys	Getsockopt(s Handle, level int32, optname int32, optval *byte, optlen *int32) (err error) [failretval==socket_error] = ws2_32.getsockopt
 //sys	bind(s Handle, name unsafe.Pointer, namelen int32) (err error) [failretval==socket_error] = ws2_32.bind
@@ -1134,8 +1134,9 @@ func Accept(fd Handle) (nfd Handle, sa Sockaddr, err error) { return 0, nil, sys
 
 func Recvfrom(fd Handle, p []byte, flags int) (n int, from Sockaddr, err error) {
 	var rsa RawSockaddrAny
-	l := int(unsafe.Sizeof(rsa))
-	n, err = recvfrom(fd, p, flags, &rsa, &l)
+	l := int32(unsafe.Sizeof(rsa))
+	n32, err := recvfrom(fd, p, int32(flags), &rsa, &l)
+	n = int(n32)
 	if err != nil {
 		return
 	}
@@ -1148,7 +1149,7 @@ func Sendto(fd Handle, p []byte, flags int, to Sockaddr) (err error) {
 	if err != nil {
 		return err
 	}
-	return sendto(fd, p, flags, ptr, l)
+	return sendto(fd, p, int32(flags), ptr, l)
 }
 
 func SetsockoptTimeval(fd Handle, level, opt int, tv *Timeval) (err error) { return syscall.EWINDOWS }

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -2875,7 +2875,7 @@ func socket(af int32, typ int32, protocol int32) (handle Handle, err error) {
 	return
 }
 
-func sendto(s Handle, buf []byte, flags int, to unsafe.Pointer, tolen int32) (err error) {
+func sendto(s Handle, buf []byte, flags int32, to unsafe.Pointer, tolen int32) (err error) {
 	var _p0 *byte
 	if len(buf) > 0 {
 		_p0 = &buf[0]
@@ -2891,13 +2891,13 @@ func sendto(s Handle, buf []byte, flags int, to unsafe.Pointer, tolen int32) (er
 	return
 }
 
-func recvfrom(s Handle, buf []byte, flags int, from *RawSockaddrAny, fromlen *int) (n int, err error) {
+func recvfrom(s Handle, buf []byte, flags int32, from *RawSockaddrAny, fromlen *int32) (n int32, err error) {
 	var _p0 *byte
 	if len(buf) > 0 {
 		_p0 = &buf[0]
 	}
 	r0, _, e1 := syscall.Syscall6(procrecvfrom.Addr(), 6, uintptr(s), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(flags), uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(fromlen)))
-	n = int(r0)
+	n = int32(r0)
 	if n == -1 {
 		if e1 != 0 {
 			err = errnoErr(e1)


### PR DESCRIPTION
Fixes wrong data type used in Windows recvfrom and sendto calls

In Windows, `int` refers to a 32-bit signed integer 
(https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types#int).
However, the current implementation (https://golang.org/cl/208321)
uses the `int` type, which can have a different size. This is especially
important when recvfrom` returns a 32bit value of `-1`, indicating an error,
since it is interpreted as the 64bit value 4294967295.