### PR TITLE
unix: fix mips64le missing InotifyInit

### DIFF
--- a/unix/syscall_linux_mips64x.go
+++ b/unix/syscall_linux_mips64x.go
@@ -224,3 +224,14 @@ func Poll(fds []PollFd, timeout int) (n int, err error) {
 	}
 	return poll(&fds[0], len(fds), timeout)
 }
+
+// Fix mips64le missing InotifyInit
+
+func InotifyInit() (fd int, err error) {
+       r0, _, e1 := RawSyscall(SYS_INOTIFY_INIT, 0, 0, 0)
+       fd = int(r0)
+       if e1 != 0 {
+               err = errnoErr(e1)
+       }
+       return
+}


### PR DESCRIPTION
unix: Fix mips64le missing InotifyInit
