### PR TITLE
unix: only declare PtraceGetFsBase() on x86-based platforms

### DIFF
--- a/unix/syscall_freebsd.go
+++ b/unix/syscall_freebsd.go
@@ -521,10 +521,6 @@ func PtraceGetFpRegs(pid int, fpregsout *FpReg) (err error) {
 	return ptrace(PTRACE_GETFPREGS, pid, uintptr(unsafe.Pointer(fpregsout)), 0)
 }
 
-func PtraceGetFsBase(pid int, fsbase *int64) (err error) {
-	return ptrace(PTRACE_GETFSBASE, pid, uintptr(unsafe.Pointer(fsbase)), 0)
-}
-
 func PtraceGetRegs(pid int, regsout *Reg) (err error) {
 	return ptrace(PTRACE_GETREGS, pid, uintptr(unsafe.Pointer(regsout)), 0)
 }

--- a/unix/syscall_freebsd_386.go
+++ b/unix/syscall_freebsd_386.go
@@ -55,6 +55,10 @@ func sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
 
 func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
+func PtraceGetFsBase(pid int, fsbase *int64) (err error) {
+	return ptrace(PTRACE_GETFSBASE, pid, uintptr(unsafe.Pointer(fsbase)), 0)
+}
+
 func PtraceIO(req int, pid int, addr uintptr, out []byte, countin int) (count int, err error) {
 	ioDesc := PtraceIoDesc{Op: int32(req), Offs: (*byte)(unsafe.Pointer(addr)), Addr: (*byte)(unsafe.Pointer(&out[0])), Len: uint32(countin)}
 	err = ptrace(PTRACE_IO, pid, uintptr(unsafe.Pointer(&ioDesc)), 0)

--- a/unix/syscall_freebsd_amd64.go
+++ b/unix/syscall_freebsd_amd64.go
@@ -55,6 +55,10 @@ func sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
 
 func Syscall9(num, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
+func PtraceGetFsBase(pid int, fsbase *int64) (err error) {
+	return ptrace(PTRACE_GETFSBASE, pid, uintptr(unsafe.Pointer(fsbase)), 0)
+}
+
 func PtraceIO(req int, pid int, addr uintptr, out []byte, countin int) (count int, err error) {
 	ioDesc := PtraceIoDesc{Op: int32(req), Offs: (*byte)(unsafe.Pointer(addr)), Addr: (*byte)(unsafe.Pointer(&out[0])), Len: uint64(countin)}
 	err = ptrace(PTRACE_IO, pid, uintptr(unsafe.Pointer(&ioDesc)), 0)


### PR DESCRIPTION
Only x86-based CPUs have an FSBASE. The current code happens to build
on FreeBSD/aarch64 and FreeBSD/arm, but that's only because we
incorrectly declare PTRACE_GETFSBASE on those platforms.