### PR TITLE
windows: fix -d=checkptr slice failures

### DIFF
--- a/unix/syscall_aix.go
+++ b/unix/syscall_aix.go
@@ -235,7 +235,7 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 			}
 		}
 
-		bytes := (*[10000]byte)(unsafe.Pointer(&pp.Path[0]))[0:n]
+		bytes := (*[10000]byte)(unsafe.Pointer(&pp.Path[0]))[0:n:n]
 		sa.Name = string(bytes)
 		return sa, nil
 

--- a/unix/syscall_aix.go
+++ b/unix/syscall_aix.go
@@ -235,7 +235,7 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 			}
 		}
 
-		bytes := (*[10000]byte)(unsafe.Pointer(&pp.Path[0]))[0:n:n]
+		bytes := (*[10000]byte)(unsafe.Pointer(&pp.Path[0]))[0:n]
 		sa.Name = string(bytes)
 		return sa, nil
 

--- a/windows/env_windows.go
+++ b/windows/env_windows.go
@@ -39,7 +39,7 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
 	defer DestroyEnvironmentBlock(block)
 	blockp := uintptr(unsafe.Pointer(block))
 	for {
-		entry := UTF16PtrToString((*uint16)(unsafe.Pointer(blockp)), (1<<30)-1)
+		entry := UTF16PtrToString((*uint16)(unsafe.Pointer(blockp)))
 		if len(entry) == 0 {
 			break
 		}

--- a/windows/env_windows.go
+++ b/windows/env_windows.go
@@ -8,7 +8,6 @@ package windows
 
 import (
 	"syscall"
-	"unicode/utf16"
 	"unsafe"
 )
 
@@ -40,17 +39,11 @@ func (token Token) Environ(inheritExisting bool) (env []string, err error) {
 	defer DestroyEnvironmentBlock(block)
 	blockp := uintptr(unsafe.Pointer(block))
 	for {
-		entry := (*[(1 << 30) - 1]uint16)(unsafe.Pointer(blockp))[:]
-		for i, v := range entry {
-			if v == 0 {
-				entry = entry[:i]
-				break
-			}
-		}
+		entry := UTF16PtrToString((*uint16)(unsafe.Pointer(blockp)), (1<<30)-1)
 		if len(entry) == 0 {
 			break
 		}
-		env = append(env, string(utf16.Decode(entry)))
+		env = append(env, entry)
 		blockp += 2 * (uintptr(len(entry)) + 1)
 	}
 	return env, nil

--- a/windows/security_windows.go
+++ b/windows/security_windows.go
@@ -1224,12 +1224,13 @@ func (sd *SECURITY_DESCRIPTOR) IsValid() bool {
 // used with %v formatting directives.
 func (sd *SECURITY_DESCRIPTOR) String() string {
 	var sddl *uint16
-	err := convertSecurityDescriptorToStringSecurityDescriptor(sd, 1, 0xff, &sddl, nil)
+	var strLen uint32
+	err := convertSecurityDescriptorToStringSecurityDescriptor(sd, 1, 0xff, &sddl, &strLen)
 	if err != nil {
 		return ""
 	}
 	defer LocalFree(Handle(unsafe.Pointer(sddl)))
-	return UTF16ToString((*[(1 << 30) - 1]uint16)(unsafe.Pointer(sddl))[:])
+	return UTF16ToString((*[(1 << 30) - 1]uint16)(unsafe.Pointer(sddl))[:strLen:strLen])
 }
 
 // ToAbsolute converts a self-relative security descriptor into an absolute one.
@@ -1308,7 +1309,7 @@ func (absoluteSD *SECURITY_DESCRIPTOR) ToSelfRelative() (selfRelativeSD *SECURIT
 
 func (selfRelativeSD *SECURITY_DESCRIPTOR) copySelfRelativeSecurityDescriptor() *SECURITY_DESCRIPTOR {
 	sdBytes := make([]byte, selfRelativeSD.Length())
-	copy(sdBytes, (*[(1 << 31) - 1]byte)(unsafe.Pointer(selfRelativeSD))[:len(sdBytes)])
+	copy(sdBytes, (*[(1 << 31) - 1]byte)(unsafe.Pointer(selfRelativeSD))[:len(sdBytes):len(sdBytes)])
 	return (*SECURITY_DESCRIPTOR)(unsafe.Pointer(&sdBytes[0]))
 }
 
@@ -1391,6 +1392,6 @@ func ACLFromEntries(explicitEntries []EXPLICIT_ACCESS, mergedACL *ACL) (acl *ACL
 	}
 	defer LocalFree(Handle(unsafe.Pointer(winHeapACL)))
 	aclBytes := make([]byte, winHeapACL.aclSize)
-	copy(aclBytes, (*[(1 << 31) - 1]byte)(unsafe.Pointer(winHeapACL))[:len(aclBytes)])
+	copy(aclBytes, (*[(1 << 31) - 1]byte)(unsafe.Pointer(winHeapACL))[:len(aclBytes):len(aclBytes)])
 	return (*ACL)(unsafe.Pointer(&aclBytes[0])), nil
 }

--- a/windows/security_windows.go
+++ b/windows/security_windows.go
@@ -1230,7 +1230,7 @@ func (sd *SECURITY_DESCRIPTOR) String() string {
 		return ""
 	}
 	defer LocalFree(Handle(unsafe.Pointer(sddl)))
-	return UTF16PtrToString(sddl, int(strLen))
+	return UTF16PtrToString(sddl)
 }
 
 // ToAbsolute converts a self-relative security descriptor into an absolute one.

--- a/windows/security_windows.go
+++ b/windows/security_windows.go
@@ -1230,7 +1230,7 @@ func (sd *SECURITY_DESCRIPTOR) String() string {
 		return ""
 	}
 	defer LocalFree(Handle(unsafe.Pointer(sddl)))
-	return UTF16ToString((*[(1 << 30) - 1]uint16)(unsafe.Pointer(sddl))[:strLen:strLen])
+	return UTF16PtrToString(sddl, int(strLen))
 }
 
 // ToAbsolute converts a self-relative security descriptor into an absolute one.

--- a/windows/svc/mgr/config.go
+++ b/windows/svc/mgr/config.go
@@ -8,7 +8,6 @@ package mgr
 
 import (
 	"syscall"
-	"unicode/utf16"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -51,20 +50,23 @@ func toString(p *uint16) string {
 }
 
 func toStringSlice(ps *uint16) []string {
-	if ps == nil {
-		return nil
-	}
 	r := make([]string, 0)
-	for from, i, p := 0, 0, (*[1 << 24]uint16)(unsafe.Pointer(ps)); true; i++ {
-		if p[i] == 0 {
-			// empty string marks the end
-			if i <= from {
-				break
-			}
-			r = append(r, string(utf16.Decode(p[from:i])))
-			from = i + 1
-		}
+	p := unsafe.Pointer(ps)
+
+	offset := func(count int) uintptr {
+		return unsafe.Sizeof(uint16(0)) * (uintptr)(count)
 	}
+
+	for {
+		s := windows.UTF16PtrToString((*uint16)(p), 4096)
+		if s == "" {
+			break
+		}
+
+		r = append(r, s)
+		p = unsafe.Pointer(uintptr(p) + offset(len(s)+1))
+	}
+
 	return r
 }
 

--- a/windows/svc/mgr/config.go
+++ b/windows/svc/mgr/config.go
@@ -47,9 +47,6 @@ type Config struct {
 }
 
 func toString(p *uint16) string {
-	if p == nil {
-		return ""
-	}
 	return windows.UTF16PtrToString(p, 4096)
 }
 

--- a/windows/svc/mgr/config.go
+++ b/windows/svc/mgr/config.go
@@ -45,26 +45,19 @@ type Config struct {
 	DelayedAutoStart bool   // the service is started after other auto-start services are started plus a short delay
 }
 
-func toString(p *uint16) string {
-	return windows.UTF16PtrToString(p, 4096)
-}
-
 func toStringSlice(ps *uint16) []string {
 	r := make([]string, 0)
 	p := unsafe.Pointer(ps)
 
-	offset := func(count int) uintptr {
-		return unsafe.Sizeof(uint16(0)) * (uintptr)(count)
-	}
-
 	for {
-		s := windows.UTF16PtrToString((*uint16)(p), 4096)
-		if s == "" {
+		s := windows.UTF16PtrToString((*uint16)(p))
+		if len(s) == 0 {
 			break
 		}
 
 		r = append(r, s)
-		p = unsafe.Pointer(uintptr(p) + offset(len(s)+1))
+		offset := unsafe.Sizeof(uint16(0)) * (uintptr)(len(s)+1)
+		p = unsafe.Pointer(uintptr(p) + offset)
 	}
 
 	return r
@@ -109,13 +102,13 @@ func (s *Service) Config() (Config, error) {
 		ServiceType:      p.ServiceType,
 		StartType:        p.StartType,
 		ErrorControl:     p.ErrorControl,
-		BinaryPathName:   toString(p.BinaryPathName),
-		LoadOrderGroup:   toString(p.LoadOrderGroup),
+		BinaryPathName:   windows.UTF16PtrToString(p.BinaryPathName),
+		LoadOrderGroup:   windows.UTF16PtrToString(p.LoadOrderGroup),
 		TagId:            p.TagId,
 		Dependencies:     toStringSlice(p.Dependencies),
-		ServiceStartName: toString(p.ServiceStartName),
-		DisplayName:      toString(p.DisplayName),
-		Description:      toString(p2.Description),
+		ServiceStartName: windows.UTF16PtrToString(p.ServiceStartName),
+		DisplayName:      windows.UTF16PtrToString(p.DisplayName),
+		Description:      windows.UTF16PtrToString(p2.Description),
 		DelayedAutoStart: delayedStart,
 	}, nil
 }

--- a/windows/svc/mgr/config.go
+++ b/windows/svc/mgr/config.go
@@ -50,7 +50,7 @@ func toString(p *uint16) string {
 	if p == nil {
 		return ""
 	}
-	return syscall.UTF16ToString((*[4096]uint16)(unsafe.Pointer(p))[:])
+	return windows.UTF16PtrToString(p, 4096)
 }
 
 func toStringSlice(ps *uint16) []string {

--- a/windows/svc/mgr/mgr.go
+++ b/windows/svc/mgr/mgr.go
@@ -73,7 +73,7 @@ func (m *Mgr) LockStatus() (*LockStatus, error) {
 		status := &LockStatus{
 			IsLocked: lockStatus.IsLocked != 0,
 			Age:      time.Duration(lockStatus.LockDuration) * time.Second,
-			Owner:    toString(lockStatus.LockOwner),
+			Owner:    windows.UTF16PtrToString(lockStatus.LockOwner),
 		}
 		return status, nil
 	}
@@ -204,7 +204,7 @@ func (m *Mgr) ListServices() ([]string, error) {
 	services := (*[1 << 20]windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0]))[:servicesReturned:servicesReturned]
 	var names []string
 	for _, s := range services {
-		name := toString(s.ServiceName)
+		name := windows.UTF16PtrToString(s.ServiceName)
 		names = append(names, name)
 	}
 	return names, nil

--- a/windows/svc/mgr/mgr.go
+++ b/windows/svc/mgr/mgr.go
@@ -73,7 +73,7 @@ func (m *Mgr) LockStatus() (*LockStatus, error) {
 		status := &LockStatus{
 			IsLocked: lockStatus.IsLocked != 0,
 			Age:      time.Duration(lockStatus.LockDuration) * time.Second,
-			Owner:    windows.UTF16ToString((*[(1 << 30) - 1]uint16)(unsafe.Pointer(lockStatus.LockOwner))[:]),
+			Owner:    toString(lockStatus.LockOwner),
 		}
 		return status, nil
 	}
@@ -204,7 +204,7 @@ func (m *Mgr) ListServices() ([]string, error) {
 	services := (*[1 << 20]windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0]))[:servicesReturned:servicesReturned]
 	var names []string
 	for _, s := range services {
-		name := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(s.ServiceName))[:])
+		name := toString(s.ServiceName)
 		names = append(names, name)
 	}
 	return names, nil

--- a/windows/svc/mgr/mgr.go
+++ b/windows/svc/mgr/mgr.go
@@ -201,7 +201,7 @@ func (m *Mgr) ListServices() ([]string, error) {
 	if servicesReturned == 0 {
 		return nil, nil
 	}
-	services := (*[1 << 20]windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0]))[:servicesReturned]
+	services := (*[1 << 20]windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0]))[:servicesReturned:servicesReturned]
 	var names []string
 	for _, s := range services {
 		name := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(s.ServiceName))[:])

--- a/windows/svc/mgr/recovery.go
+++ b/windows/svc/mgr/recovery.go
@@ -69,7 +69,7 @@ func (s *Service) RecoveryActions() ([]RecoveryAction, error) {
 	}
 
 	var recoveryActions []RecoveryAction
-	actions := (*[1024]windows.SC_ACTION)(unsafe.Pointer(p.Actions))[:p.ActionsCount]
+	actions := (*[1024]windows.SC_ACTION)(unsafe.Pointer(p.Actions))[:p.ActionsCount:p.ActionsCount]
 	for _, action := range actions {
 		recoveryActions = append(recoveryActions, RecoveryAction{Type: int(action.Type), Delay: time.Duration(action.Delay) * time.Millisecond})
 	}

--- a/windows/svc/mgr/recovery.go
+++ b/windows/svc/mgr/recovery.go
@@ -112,7 +112,7 @@ func (s *Service) RebootMessage() (string, error) {
 		return "", err
 	}
 	p := (*windows.SERVICE_FAILURE_ACTIONS)(unsafe.Pointer(&b[0]))
-	return toString(p.RebootMsg), nil
+	return windows.UTF16PtrToString(p.RebootMsg), nil
 }
 
 // SetRecoveryCommand sets the command line of the process to execute in response to the RunCommand service controller action.
@@ -131,5 +131,5 @@ func (s *Service) RecoveryCommand() (string, error) {
 		return "", err
 	}
 	p := (*windows.SERVICE_FAILURE_ACTIONS)(unsafe.Pointer(&b[0]))
-	return toString(p.Command), nil
+	return windows.UTF16PtrToString(p.Command), nil
 }

--- a/windows/svc/mgr/recovery.go
+++ b/windows/svc/mgr/recovery.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unsafe"
 
+	"golang.org/x/sys/internal/unsafeheader"
 	"golang.org/x/sys/windows"
 )
 
@@ -68,8 +69,13 @@ func (s *Service) RecoveryActions() ([]RecoveryAction, error) {
 		return nil, err
 	}
 
+	var actions []windows.SC_ACTION
+	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&actions))
+	hdr.Data = unsafe.Pointer(p.Actions)
+	hdr.Len = int(p.ActionsCount)
+	hdr.Cap = int(p.ActionsCount)
+
 	var recoveryActions []RecoveryAction
-	actions := (*[1024]windows.SC_ACTION)(unsafe.Pointer(p.Actions))[:p.ActionsCount:p.ActionsCount]
 	for _, action := range actions {
 		recoveryActions = append(recoveryActions, RecoveryAction{Type: int(action.Type), Delay: time.Duration(action.Delay) * time.Millisecond})
 	}

--- a/windows/svc/security.go
+++ b/windows/svc/security.go
@@ -7,8 +7,6 @@
 package svc
 
 import (
-	"unsafe"
-
 	"golang.org/x/sys/windows"
 )
 
@@ -48,9 +46,8 @@ func IsAnInteractiveSession() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	p := unsafe.Pointer(&gs.Groups[0])
-	groups := (*[2 << 20]windows.SIDAndAttributes)(p)[:gs.GroupCount]
-	for _, g := range groups {
+
+	for _, g := range gs.AllGroups() {
 		if windows.EqualSid(g.Sid, interSid) {
 			return true, nil
 		}

--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -224,10 +224,10 @@ const (
 func (s *service) run() {
 	s.goWaits.Wait()
 	s.h = windows.Handle(ssHandle)
-	argv := (*[100]*int16)(unsafe.Pointer(sArgv))[:sArgc:sArgc]
+	argv := (*[100]*uint16)(unsafe.Pointer(sArgv))[:sArgc:sArgc]
 	args := make([]string, len(argv))
 	for i, a := range argv {
-		args[i] = syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(a))[:])
+		args[i] = windows.UTF16PtrToString(a, 1<<20)
 	}
 
 	cmdsToHandler := make(chan ChangeRequest)

--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -224,7 +224,7 @@ const (
 func (s *service) run() {
 	s.goWaits.Wait()
 	s.h = windows.Handle(ssHandle)
-	argv := (*[100]*int16)(unsafe.Pointer(sArgv))[:sArgc]
+	argv := (*[100]*int16)(unsafe.Pointer(sArgv))[:sArgc:sArgc]
 	args := make([]string, len(argv))
 	for i, a := range argv {
 		args[i] = syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(a))[:])

--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -227,7 +227,7 @@ func (s *service) run() {
 	argv := (*[100]*uint16)(unsafe.Pointer(sArgv))[:sArgc:sArgc]
 	args := make([]string, len(argv))
 	for i, a := range argv {
-		args[i] = windows.UTF16PtrToString(a, 1<<20)
+		args[i] = windows.UTF16PtrToString(a)
 	}
 
 	cmdsToHandler := make(chan ChangeRequest)

--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"golang.org/x/sys/internal/unsafeheader"
 	"golang.org/x/sys/windows"
 )
 
@@ -224,7 +225,13 @@ const (
 func (s *service) run() {
 	s.goWaits.Wait()
 	s.h = windows.Handle(ssHandle)
-	argv := (*[100]*uint16)(unsafe.Pointer(sArgv))[:sArgc:sArgc]
+
+	var argv []*uint16
+	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&argv))
+	hdr.Data = unsafe.Pointer(sArgv)
+	hdr.Len = int(sArgc)
+	hdr.Cap = int(sArgc)
+
 	args := make([]string, len(argv))
 	for i, a := range argv {
 		args[i] = windows.UTF16PtrToString(a)

--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -126,6 +126,10 @@ func UTF16PtrToString(p *uint16) string {
 	if p == nil {
 		return ""
 	}
+	if *p == 0 {
+		return ""
+	}
+
 	// Find NUL terminator.
 	n := 0
 	for ptr := unsafe.Pointer(p); *(*uint16)(ptr) != 0; n++ {

--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -117,6 +117,25 @@ func UTF16PtrFromString(s string) (*uint16, error) {
 	return &a[0], nil
 }
 
+// UTF16PtrToString is like UTF16ToString, but takes *uint16
+// as a parameter instead of []uint16.
+// max is how many times p can be advanced looking for the null terminator.
+// If max is hit, the string is truncated at that point.
+func UTF16PtrToString(p *uint16, max int) string {
+	if p == nil {
+		return ""
+	}
+	// Find NUL terminator.
+	end := unsafe.Pointer(p)
+	n := 0
+	for *(*uint16)(end) != 0 && n < max {
+		end = unsafe.Pointer(uintptr(end) + unsafe.Sizeof(*p))
+		n++
+	}
+	s := (*[(1 << 30) - 1]uint16)(unsafe.Pointer(p))[:n:n]
+	return string(utf16.Decode(s))
+}
+
 func Getpagesize() int { return 4096 }
 
 // NewCallback converts a Go function to a function pointer conforming to the stdcall calling convention.
@@ -1383,7 +1402,7 @@ func (t Token) KnownFolderPath(folderID *KNOWNFOLDERID, flags uint32) (string, e
 		return "", err
 	}
 	defer CoTaskMemFree(unsafe.Pointer(p))
-	return UTF16ToString((*[(1 << 30) - 1]uint16)(unsafe.Pointer(p))[:]), nil
+	return UTF16PtrToString(p, (1<<30)-1), nil
 }
 
 // RtlGetVersion returns the version of the underlying operating system, ignoring


### PR DESCRIPTION
This CL fixes unsafe casts to slices that are missing length or capacity.

Running tests with -d=checkptr enabled may panic on casting unsafe.Pointer to a static array of large predefined length, that is most likely much bigger than the size of the actual array in memory. Checkptr check is not satisfied if slicing operator misses length and capacity arguments `(*[(1 << 30) - 1]uint16)(unsafe.Pointer(p))[:]`, or when there is no slicing at all `(*[(1 << 30) - 1]uint16)(unsafe.Pointer(p))`.

To find all potential cases I used `grep -nr ")(unsafe.Pointer(" ./windows`, then filtered out safe casts when object size is always static and known at compile time.

To reproduce the issue run tests with checkptr enabled `go test -a -gcflags=all=-d=checkptr ./windows/...`. 

Updates golang/go#34972
Fixes golang/go#38355