### PR TITLE
unix: fix -d=checkptr slice failures on aix

### DIFF
--- a/unix/syscall_aix.go
+++ b/unix/syscall_aix.go
@@ -235,7 +235,7 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 			}
 		}
 
-		bytes := (*[10000]byte)(unsafe.Pointer(&pp.Path[0]))[0:n:n]
+		bytes := (*[len(pp.Path)]byte)(unsafe.Pointer(&pp.Path[0]))[0:n]
 		sa.Name = string(bytes)
 		return sa, nil
 

--- a/unix/syscall_aix.go
+++ b/unix/syscall_aix.go
@@ -235,7 +235,7 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 			}
 		}
 
-		bytes := (*[10000]byte)(unsafe.Pointer(&pp.Path[0]))[0:n]
+		bytes := (*[10000]byte)(unsafe.Pointer(&pp.Path[0]))[0:n:n]
 		sa.Name = string(bytes)
 		return sa, nil
 


### PR DESCRIPTION
Fix unsafe conversions to slices that are missing length or capacity.