### PR TITLE
unix: add SO_ORIGINAL_DST const

### DIFF
--- a/unix/zerrors_linux_386.go
+++ b/unix/zerrors_linux_386.go
@@ -317,6 +317,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_amd64.go
+++ b/unix/zerrors_linux_amd64.go
@@ -318,6 +318,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_arm.go
+++ b/unix/zerrors_linux_arm.go
@@ -324,6 +324,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_arm64.go
+++ b/unix/zerrors_linux_arm64.go
@@ -310,6 +310,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	SVE_MAGIC                        = 0x53564501
 	TAB1                             = 0x800
 	TAB2                             = 0x1000

--- a/unix/zerrors_linux_mips.go
+++ b/unix/zerrors_linux_mips.go
@@ -318,6 +318,7 @@ const (
 	SO_TYPE                          = 0x1008
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_mips64.go
+++ b/unix/zerrors_linux_mips64.go
@@ -318,6 +318,7 @@ const (
 	SO_TYPE                          = 0x1008
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_mips64le.go
+++ b/unix/zerrors_linux_mips64le.go
@@ -318,6 +318,7 @@ const (
 	SO_TYPE                          = 0x1008
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_mipsle.go
+++ b/unix/zerrors_linux_mipsle.go
@@ -318,6 +318,7 @@ const (
 	SO_TYPE                          = 0x1008
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_ppc64.go
+++ b/unix/zerrors_linux_ppc64.go
@@ -376,6 +376,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x400
 	TAB2                             = 0x800
 	TAB3                             = 0xc00

--- a/unix/zerrors_linux_ppc64le.go
+++ b/unix/zerrors_linux_ppc64le.go
@@ -376,6 +376,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x400
 	TAB2                             = 0x800
 	TAB3                             = 0xc00

--- a/unix/zerrors_linux_riscv64.go
+++ b/unix/zerrors_linux_riscv64.go
@@ -305,6 +305,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_s390x.go
+++ b/unix/zerrors_linux_s390x.go
@@ -378,6 +378,7 @@ const (
 	SO_TYPE                          = 0x3
 	SO_WIFI_STATUS                   = 0x29
 	SO_ZEROCOPY                      = 0x3c
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800

--- a/unix/zerrors_linux_sparc64.go
+++ b/unix/zerrors_linux_sparc64.go
@@ -371,6 +371,7 @@ const (
 	SO_TYPE                          = 0x1008
 	SO_WIFI_STATUS                   = 0x25
 	SO_ZEROCOPY                      = 0x3e
+	SO_ORIGINAL_DST                  = 0x50
 	TAB1                             = 0x800
 	TAB2                             = 0x1000
 	TAB3                             = 0x1800


### PR DESCRIPTION
This adds SO_ORIGINAL_DST which is introduced in netfilter.

For more information, see source code: https://github.com/torvalds/linux/blob/master/include/uapi/linux/netfilter_ipv4.h#L52