### PR TITLE
bytes2iovec: fix range iterator issue

### DIFF
--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -1803,7 +1803,7 @@ func bytes2iovec(bs [][]byte) []Iovec {
 	for i, b := range bs {
 		iovecs[i].SetLen(len(b))
 		if len(b) > 0 {
-			iovecs[i].Base = &b[0]
+			iovecs[i].Base = &bs[i][0]
 		} else {
 			iovecs[i].Base = (*byte)(unsafe.Pointer(&_zero))
 		}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Go uses the same address variable while iterating in a range, so use a copy when using its address, otherwise we end up using the last value for all iterations.