### PR TITLE
Prevent seccomp crash on android emulator by trying to use pipe2

### DIFF
--- a/unix/syscall_linux_386.go
+++ b/unix/syscall_linux_386.go
@@ -28,7 +28,11 @@ func Pipe(p []int) (err error) {
 		return EINVAL
 	}
 	var pp [2]_C_int
-	err = pipe(&pp)
+	// Try pipe2 first for Android O, then try pipe for kernel 2.6.23.
+	err = pipe2(&pp, 0)
+	if err == ENOSYS {
+		err = pipe(&pp)
+	}
 	p[0] = int(pp[0])
 	p[1] = int(pp[1])
 	return

--- a/unix/syscall_linux_amd64.go
+++ b/unix/syscall_linux_amd64.go
@@ -132,7 +132,11 @@ func Pipe(p []int) (err error) {
 		return EINVAL
 	}
 	var pp [2]_C_int
-	err = pipe(&pp)
+	// Try pipe2 first for Android O, then try pipe for kernel 2.6.23.
+	err = pipe2(&pp, 0)
+	if err == ENOSYS {
+		err = pipe(&pp)
+	}
 	p[0] = int(pp[0])
 	p[1] = int(pp[1])
 	return


### PR DESCRIPTION
This fixes https://github.com/golang/go/issues/40828.

It just copies the fix from this commit: https://go-review.googlesource.com/c/go/+/165217/