### PR TITLE
unix: add AF_IUCV and SockaddrIUCV

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -257,6 +257,16 @@ struct my_sockaddr_un {
 #endif
 };
 
+// copied from /usr/include/netiucv/iucv.h modified with explicit signed chars.
+struct sockaddr_iucv {
+	sa_family_t siucv_family;
+	unsigned short siucv_port;
+	unsigned int siucv_addr;
+	signed char siucv_nodeid[8];
+	signed char siucv_user_id[8];
+	signed char siucv_name[8];
+};
+
 #ifdef __ARM_EABI__
 typedef struct user_regs PtraceRegs;
 #elif defined(__aarch64__)

--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -540,6 +540,8 @@ type RawSockaddrL2TPIP C.struct_sockaddr_l2tpip
 
 type RawSockaddrL2TPIP6 C.struct_sockaddr_l2tpip6
 
+type RawSockaddrIUCV C.struct_sockaddr_iucv
+
 type RawSockaddr C.struct_sockaddr
 
 type RawSockaddrAny C.struct_sockaddr_any
@@ -594,6 +596,7 @@ const (
 	SizeofSockaddrTIPC      = C.sizeof_struct_sockaddr_tipc
 	SizeofSockaddrL2TPIP    = C.sizeof_struct_sockaddr_l2tpip
 	SizeofSockaddrL2TPIP6   = C.sizeof_struct_sockaddr_l2tpip6
+	SizeofSockaddrIUCV      = C.sizeof_struct_sockaddr_iucv
 	SizeofLinger            = C.sizeof_struct_linger
 	SizeofIovec             = C.sizeof_struct_iovec
 	SizeofIPMreq            = C.sizeof_struct_ip_mreq

--- a/unix/syscall_internal_linux_test.go
+++ b/unix/syscall_internal_linux_test.go
@@ -157,6 +157,18 @@ func Test_anyToSockaddr(t *testing.T) {
 			},
 		},
 		{
+			name: "AF_IUCV",
+			rsa: sockaddrIUCVToAny(RawSockaddrIUCV{
+				Family:  AF_IUCV,
+				User_id: [8]int8{'*', 'M', 'S', 'G', ' ', ' ', ' ', ' '},
+				Name:    [8]int8{' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+			}),
+			sa: &SockaddrIUCV{
+				UserID: "*MSG    ",
+				Name:   "        ",
+			},
+		},
+		{
 			name: "AF_MAX EAFNOSUPPORT",
 			rsa: &RawSockaddrAny{
 				Addr: RawSockaddr{
@@ -503,5 +515,14 @@ func sockaddrUnixToAny(in RawSockaddrUnix) *RawSockaddrAny {
 		(*(*[SizeofSockaddrUnix]byte)(unsafe.Pointer(&in)))[:],
 	)
 
+	return &out
+}
+
+func sockaddrIUCVToAny(in RawSockaddrIUCV) *RawSockaddrAny {
+	var out RawSockaddrAny
+	copy(
+		(*(*[SizeofSockaddrAny]byte)(unsafe.Pointer(&out)))[:],
+		(*(*[SizeofSockaddrUnix]byte)(unsafe.Pointer(&in)))[:],
+	)
 	return &out
 }

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -885,6 +885,25 @@ func (sa *SockaddrL2TPIP6) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	return unsafe.Pointer(&sa.raw), SizeofSockaddrL2TPIP6, nil
 }
 
+// SockaddrIUCV implements the Sockaddr interface for AF_IUCV sockets.
+type SockaddrIUCV struct {
+	UserID string
+	Name   string
+	raw    RawSockaddrIUCV
+}
+
+func (sa *SockaddrIUCV) sockaddr() (unsafe.Pointer, _Socklen, error) {
+	sa.raw.Family = AF_IUCV
+	for i := 0; i < 8; i++ {
+		sa.raw.Nodeid[i] = ' '
+		sa.raw.User_id[i] = ' '
+		sa.raw.Name[i] = ' '
+	}
+	copy(sa.raw.User_id[:], []byte(sa.UserID))
+	copy(sa.raw.Name[:], []byte(sa.Name))
+	return unsafe.Pointer(&sa.raw), SizeofSockaddrIUCV, nil
+}
+
 func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 	switch rsa.Addr.Family {
 	case AF_NETLINK:

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -894,6 +894,9 @@ type SockaddrIUCV struct {
 
 func (sa *SockaddrIUCV) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	sa.raw.Family = AF_IUCV
+	// These are EBCDIC encoded by the kernel, but we still need to pad them
+	// with blanks. Initializing with blanks allows the caller to feed in either
+	// a padded or an unpadded string.
 	for i := 0; i < 8; i++ {
 		sa.raw.Nodeid[i] = ' '
 		sa.raw.User_id[i] = ' '

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -310,6 +310,15 @@ type RawSockaddrL2TPIP6 struct {
 	Conn_id  uint32
 }
 
+type RawSockaddrIUCV struct {
+	Family   uint16
+	Port     uint16
+	Addr     uint32
+	Nodeid   [8]byte
+	User_id  [8]byte
+	Name     [8]byte
+}
+
 type _Socklen uint32
 
 type Linger struct {
@@ -422,6 +431,7 @@ const (
 	SizeofSockaddrTIPC      = 0x10
 	SizeofSockaddrL2TPIP    = 0x10
 	SizeofSockaddrL2TPIP6   = 0x20
+	SizeofSockaddrIUCV      = 0x20
 	SizeofLinger            = 0x8
 	SizeofIPMreq            = 0x8
 	SizeofIPMreqn           = 0xc

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -311,12 +311,12 @@ type RawSockaddrL2TPIP6 struct {
 }
 
 type RawSockaddrIUCV struct {
-	Family   uint16
-	Port     uint16
-	Addr     uint32
-	Nodeid   [8]byte
-	User_id  [8]byte
-	Name     [8]byte
+	Family  uint16
+	Port    uint16
+	Addr    uint32
+	Nodeid  [8]int8
+	User_id [8]int8
+	Name    [8]int8
 }
 
 type _Socklen uint32


### PR DESCRIPTION
On z series machines the IUCV address family is used to communicate
between parts of the machine and other VMs that may be running.

This adds support for addressing these services using AF_IUCV.

Fixes golang/go#40826