### PR TITLE
unix: add constants for raw CAN sockets

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -81,6 +81,7 @@ struct termios2 {
 #include <linux/blkpg.h>
 #include <linux/bpf.h>
 #include <linux/can.h>
+#include <linux/can/raw.h>
 #include <linux/capability.h>
 #include <linux/cgroupstats.h>
 #include <linux/cryptouser.h>
@@ -2480,4 +2481,15 @@ const (
 	NHA_ENCAP      = C.NHA_ENCAP
 	NHA_GROUPS     = C.NHA_GROUPS
 	NHA_MASTER     = C.NHA_MASTER
+)
+
+// raw CAN sockets
+
+const (
+	CAN_RAW_FILTER        = C.CAN_RAW_FILTER
+	CAN_RAW_ERR_FILTER    = C.CAN_RAW_ERR_FILTER
+	CAN_RAW_LOOPBACK      = C.CAN_RAW_LOOPBACK
+	CAN_RAW_RECV_OWN_MSGS = C.CAN_RAW_RECV_OWN_MSGS
+	CAN_RAW_FD_FRAMES     = C.CAN_RAW_FD_FRAMES
+	CAN_RAW_JOIN_FILTERS  = C.CAN_RAW_JOIN_FILTERS
 )

--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -194,6 +194,7 @@ struct ltchars {
 #include <linux/bpf.h>
 #include <linux/can.h>
 #include <linux/can/error.h>
+#include <linux/can/raw.h>
 #include <linux/capability.h>
 #include <linux/cryptouser.h>
 #include <linux/devlink.h>

--- a/unix/zerrors_linux.go
+++ b/unix/zerrors_linux.go
@@ -2043,6 +2043,7 @@ const (
 	SOL_ATM                                     = 0x108
 	SOL_CAIF                                    = 0x116
 	SOL_CAN_BASE                                = 0x64
+	SOL_CAN_RAW                                 = 0x65
 	SOL_DCCP                                    = 0x10d
 	SOL_DECNET                                  = 0x105
 	SOL_ICMPV6                                  = 0x3a

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -2527,3 +2527,12 @@ const (
 	NHA_GROUPS     = 0x9
 	NHA_MASTER     = 0xa
 )
+
+const (
+	CAN_RAW_FILTER        = 0x1
+	CAN_RAW_ERR_FILTER    = 0x2
+	CAN_RAW_LOOPBACK      = 0x3
+	CAN_RAW_RECV_OWN_MSGS = 0x4
+	CAN_RAW_FD_FRAMES     = 0x5
+	CAN_RAW_JOIN_FILTERS  = 0x6
+)


### PR DESCRIPTION
Fixes golang/go#41091