### PR TITLE
unix: add linux constants and types for PPS devices ioctl's

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -113,6 +113,7 @@ struct termios2 {
 #include <linux/nexthop.h>
 #include <linux/openat2.h>
 #include <linux/perf_event.h>
+#include <linux/pps.h>
 #include <linux/random.h>
 #include <linux/rtc.h>
 #include <linux/rtnetlink.h>
@@ -2576,3 +2577,20 @@ const (
 // Watchdog API
 
 type WatchdogInfo C.struct_watchdog_info
+
+// PPS API
+
+type PPSFData C.struct_pps_fdata
+
+type PPSKParams C.struct_pps_kparams
+
+type PPSKInfo C.struct_pps_kinfo
+
+type PPSKTime C.struct_pps_ktime
+
+const (
+	PPS_GETPARAMS = C.PPS_GETPARAMS
+	PPS_SETPARAMS = C.PPS_SETPARAMS
+	PPS_GETCAP    = C.PPS_GETCAP
+	PPS_FETCH     = C.PPS_FETCH
+)

--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -232,6 +232,7 @@ struct ltchars {
 #include <linux/net_namespace.h>
 #include <linux/nsfs.h>
 #include <linux/perf_event.h>
+#include <linux/pps.h>
 #include <linux/ptrace.h>
 #include <linux/random.h>
 #include <linux/reboot.h>

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -2638,3 +2638,21 @@ type WatchdogInfo struct {
 	Version  uint32
 	Identity [32]uint8
 }
+
+type PPSFData struct {
+	Info    PPSKInfo
+	Timeout PPSKTime
+}
+
+type PPSKParams struct {
+	Api_version   int32
+	Mode          int32
+	Assert_off_tu PPSKTime
+	Clear_off_tu  PPSKTime
+}
+
+type PPSKTime struct {
+	Sec   int64
+	Nsec  int32
+	Flags uint32
+}

--- a/unix/ztypes_linux_386.go
+++ b/unix/ztypes_linux_386.go
@@ -602,3 +602,18 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+}
+
+const (
+	PPS_GETPARAMS = 0x800470a1
+	PPS_SETPARAMS = 0x400470a2
+	PPS_GETCAP    = 0x800470a3
+	PPS_FETCH     = 0xc00470a4
+)

--- a/unix/ztypes_linux_amd64.go
+++ b/unix/ztypes_linux_amd64.go
@@ -619,3 +619,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x800870a1
+	PPS_SETPARAMS = 0x400870a2
+	PPS_GETCAP    = 0x800870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_arm.go
+++ b/unix/ztypes_linux_arm.go
@@ -596,3 +596,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]uint8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x800470a1
+	PPS_SETPARAMS = 0x400470a2
+	PPS_GETCAP    = 0x800470a3
+	PPS_FETCH     = 0xc00470a4
+)

--- a/unix/ztypes_linux_arm64.go
+++ b/unix/ztypes_linux_arm64.go
@@ -598,3 +598,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x800870a1
+	PPS_SETPARAMS = 0x400870a2
+	PPS_GETCAP    = 0x800870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_mips.go
+++ b/unix/ztypes_linux_mips.go
@@ -602,3 +602,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x400470a1
+	PPS_SETPARAMS = 0x800470a2
+	PPS_GETCAP    = 0x400470a3
+	PPS_FETCH     = 0xc00470a4
+)

--- a/unix/ztypes_linux_mips64.go
+++ b/unix/ztypes_linux_mips64.go
@@ -601,3 +601,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x400870a1
+	PPS_SETPARAMS = 0x800870a2
+	PPS_GETCAP    = 0x400870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_mips64le.go
+++ b/unix/ztypes_linux_mips64le.go
@@ -601,3 +601,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x400870a1
+	PPS_SETPARAMS = 0x800870a2
+	PPS_GETCAP    = 0x400870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_mipsle.go
+++ b/unix/ztypes_linux_mipsle.go
@@ -602,3 +602,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x400470a1
+	PPS_SETPARAMS = 0x800470a2
+	PPS_GETCAP    = 0x400470a3
+	PPS_FETCH     = 0xc00470a4
+)

--- a/unix/ztypes_linux_ppc64.go
+++ b/unix/ztypes_linux_ppc64.go
@@ -608,3 +608,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]uint8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x400870a1
+	PPS_SETPARAMS = 0x800870a2
+	PPS_GETCAP    = 0x400870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_ppc64le.go
+++ b/unix/ztypes_linux_ppc64le.go
@@ -608,3 +608,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]uint8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x400870a1
+	PPS_SETPARAMS = 0x800870a2
+	PPS_GETCAP    = 0x400870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_riscv64.go
+++ b/unix/ztypes_linux_riscv64.go
@@ -626,3 +626,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]uint8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x800870a1
+	PPS_SETPARAMS = 0x400870a2
+	PPS_GETCAP    = 0x800870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_s390x.go
+++ b/unix/ztypes_linux_s390x.go
@@ -622,3 +622,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x800870a1
+	PPS_SETPARAMS = 0x400870a2
+	PPS_GETCAP    = 0x800870a3
+	PPS_FETCH     = 0xc00870a4
+)

--- a/unix/ztypes_linux_sparc64.go
+++ b/unix/ztypes_linux_sparc64.go
@@ -603,3 +603,19 @@ type TIPCSIOCNodeIDReq struct {
 	Peer uint32
 	Id   [16]int8
 }
+
+type PPSKInfo struct {
+	Assert_sequence uint32
+	Clear_sequence  uint32
+	Assert_tu       PPSKTime
+	Clear_tu        PPSKTime
+	Current_mode    int32
+	_               [4]byte
+}
+
+const (
+	PPS_GETPARAMS = 0x400870a1
+	PPS_SETPARAMS = 0x800870a2
+	PPS_GETCAP    = 0x400870a3
+	PPS_FETCH     = 0xc00870a4
+)


### PR DESCRIPTION
After trying to implement Pulse Per Second devices
in go, I found that the ioctl values and structs
where not in the unix package yet:

~# strace ppstest /dev/pps0 |& grep ioctl
ioctl(3, PPS_GETPARAMS, 0xbee63b18)     = 0
ioctl(3, PPS_GETCAP, 0xbee63b84)        = 0
ioctl(3, PPS_GETPARAMS, 0xbee63b18)     = 0
ioctl(3, PPS_SETPARAMS, 0xbee63b18)     = 0
ioctl(3, PPS_FETCH, 0xbee63b00)         = 0
ioctl(3, PPS_FETCH, 0xbee63b00)         = 0
ioctl(3, PPS_FETCH, 0xbee63b00)         = 0
ioctl(3, PPS_FETCH, 0xbee63b00)         = 0
ioctl(3, PPS_FETCH, 0xbee63b00)         = 0

This commit should add them.
