### PR TITLE
unix: add J1939 protocol support on socketcan interface

### DIFF
--- a/unix/syscall_internal_linux_test.go
+++ b/unix/syscall_internal_linux_test.go
@@ -232,7 +232,7 @@ func Test_anyToSockaddr(t *testing.T) {
 					t.Skip("socket family/protocol not supported by kernel")
 				} else if  err == EAFNOSUPPORT {
 					t.Skip("socket address family not supported by kernel")
-				} else if err == EPERM {
+				} else if err == EACCES {
 					// Some platforms might require elevated privileges to perform
 					// actions on sockets. Skip the test in this situation.
 					t.Skip("socket operation not permitted")

--- a/unix/syscall_internal_linux_test.go
+++ b/unix/syscall_internal_linux_test.go
@@ -230,7 +230,7 @@ func Test_anyToSockaddr(t *testing.T) {
 				// trying to create the socket.  Skip the test in this situation.
 				if err == EPROTONOSUPPORT {
 					t.Skip("socket family/protocol not supported by kernel")
-				} else if  err == EAFNOSUPPORT {
+				} else if err == EAFNOSUPPORT {
 					t.Skip("socket address family not supported by kernel")
 				} else if err == EACCES {
 					// Some platforms might require elevated privileges to perform

--- a/unix/syscall_internal_linux_test.go
+++ b/unix/syscall_internal_linux_test.go
@@ -232,6 +232,10 @@ func Test_anyToSockaddr(t *testing.T) {
 					t.Skip("socket family/protocol not supported by kernel")
 				} else if  err == EAFNOSUPPORT {
 					t.Skip("socket address family not supported by kernel")
+				} else if err == EPERM {
+					// Some platforms might require elevated privileges to perform
+					// actions on sockets. Skip the test in this situation.
+					t.Skip("socket operation not permitted")
 				} else if err != nil {
 					t.Fatalf("socket(%v): %v", tt.skt, err)
 				}

--- a/unix/syscall_internal_linux_test.go
+++ b/unix/syscall_internal_linux_test.go
@@ -226,10 +226,12 @@ func Test_anyToSockaddr(t *testing.T) {
 			if tt.skt.domain != 0 {
 				fd, err = Socket(tt.skt.domain, tt.skt.typ, tt.skt.protocol)
 				// Some sockaddr types need specific kernel modules running: if these
-				// are not present we'll get EPROTONOSUPPORT back when trying to create
-				// the socket.  Skip the test in this situation.
+				// are not present we'll get EPROTONOSUPPORT/EAFNOSUPPORT back when
+				// trying to create the socket.  Skip the test in this situation.
 				if err == EPROTONOSUPPORT {
 					t.Skip("socket family/protocol not supported by kernel")
+				} else if  err == EAFNOSUPPORT {
+					t.Skip("socket address family not supported by kernel")
 				} else if err != nil {
 					t.Fatalf("socket(%v): %v", tt.skt, err)
 				}

--- a/unix/syscall_internal_linux_test.go
+++ b/unix/syscall_internal_linux_test.go
@@ -199,7 +199,7 @@ func Test_anyToSockaddr(t *testing.T) {
 					0xCC, 0x00, 0x00, 0x00,
 				},
 			}),
-			sa: &SockaddrJ1939{
+			sa: &SockaddrCANJ1939{
 				Ifindex: 12345678,
 				Name:    0xAAAAAAAAAAAAAAAA,
 				PGN:     0xBBBBBBBB,

--- a/unix/syscall_internal_linux_test.go
+++ b/unix/syscall_internal_linux_test.go
@@ -169,7 +169,7 @@ func Test_anyToSockaddr(t *testing.T) {
 			},
 		},
 		{
-			name: "AF_CAN",
+			name: "AF_CAN CAN_RAW",
 			rsa: sockaddrCANToAny(RawSockaddrCAN{
 				Family:  AF_CAN,
 				Ifindex: 12345678,
@@ -185,6 +185,27 @@ func Test_anyToSockaddr(t *testing.T) {
 				RxID:    0xAAAAAAAA,
 				TxID:    0xBBBBBBBB,
 			},
+			skt: SocketSpec{domain: AF_CAN, typ: SOCK_RAW, protocol: CAN_RAW},
+		},
+		{
+			name: "AF_CAN CAN_J1939",
+			rsa: sockaddrCANToAny(RawSockaddrCAN{
+				Family:  AF_CAN,
+				Ifindex: 12345678,
+				Addr: [16]byte{
+					0xAA, 0xAA, 0xAA, 0xAA,
+					0xAA, 0xAA, 0xAA, 0xAA,
+					0xBB, 0xBB, 0xBB, 0xBB,
+					0xCC, 0x00, 0x00, 0x00,
+				},
+			}),
+			sa: &SockaddrJ1939{
+				Ifindex: 12345678,
+				Name:    0xAAAAAAAAAAAAAAAA,
+				PGN:     0xBBBBBBBB,
+				Addr:    0xCC,
+			},
+			skt: SocketSpec{domain: AF_CAN, typ: SOCK_DGRAM, protocol: CAN_J1939},
 		},
 		{
 			name: "AF_MAX EAFNOSUPPORT",

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -1197,9 +1197,7 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 				pgn[i] = pp.Addr[i+8]
 			}
 			addr := (*[1]byte)(unsafe.Pointer(&sa.Addr))
-			for i := 0; i < 1; i++ {
-				addr[i] = pp.Addr[i+12]
-			}
+			addr[0] = pp.Addr[12]
 			return sa, nil
 		default:
 			sa := &SockaddrCAN{

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -1176,9 +1176,8 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 		return sa, nil
 
 	case AF_CAN:
-		var err error
-		var proto int
-		if proto, err = GetsockoptInt(fd, SOL_SOCKET, SO_PROTOCOL); err != nil {
+		proto, err := GetsockoptInt(fd, SOL_SOCKET, SO_PROTOCOL)
+		if err != nil {
 			return nil, err
 		}
 

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -641,6 +641,10 @@ func (sa *SockaddrCAN) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	return unsafe.Pointer(&sa.raw), SizeofSockaddrCAN, nil
 }
 
+// SockaddrCANJ1939 implements the Sockaddr interface for AF_CAN using J1939
+// protocol (https://en.wikipedia.org/wiki/SAE_J1939). For more information
+// on the purposes of the fields, check the official linux kernel documentation
+// available here: https://www.kernel.org/doc/Documentation/networking/j1939.rst
 type SockaddrCANJ1939 struct {
 	Ifindex int
 	Name    uint64

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -641,7 +641,7 @@ func (sa *SockaddrCAN) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	return unsafe.Pointer(&sa.raw), SizeofSockaddrCAN, nil
 }
 
-type SockaddrJ1939 struct {
+type SockaddrCANJ1939 struct {
 	Ifindex int
 	Name    uint64
 	PGN     uint32
@@ -649,7 +649,7 @@ type SockaddrJ1939 struct {
 	raw     RawSockaddrCAN
 }
 
-func (sa *SockaddrJ1939) sockaddr() (unsafe.Pointer, _Socklen, error) {
+func (sa *SockaddrCANJ1939) sockaddr() (unsafe.Pointer, _Socklen, error) {
 	if sa.Ifindex < 0 || sa.Ifindex > 0x7fffffff {
 		return nil, 0, EINVAL
 	}
@@ -1185,7 +1185,7 @@ func anyToSockaddr(fd int, rsa *RawSockaddrAny) (Sockaddr, error) {
 
 		switch proto {
 		case CAN_J1939:
-			sa := &SockaddrJ1939{
+			sa := &SockaddrCANJ1939{
 				Ifindex: int(pp.Ifindex),
 			}
 			name := (*[8]byte)(unsafe.Pointer(&sa.Name))


### PR DESCRIPTION
Fixes golang/go#42797