### PR TITLE
unix: fix and test the FIDEDUPERANGE Linux ioctl

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -473,7 +473,14 @@ type Flock_t C.struct_flock
 
 type FileCloneRange C.struct_file_clone_range
 
-type FileDedupeRange C.struct_file_dedupe_range
+type RawFileDedupeRange C.struct_file_dedupe_range
+
+type RawFileDedupeRangeInfo C.struct_file_dedupe_range_info
+
+const (
+	SizeofRawFileDedupeRange     = C.sizeof_struct_file_dedupe_range
+	SizeofRawFileDedupeRangeInfo = C.sizeof_struct_file_dedupe_range_info
+)
 
 // Filesystem Encryption
 

--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -480,6 +480,8 @@ type RawFileDedupeRangeInfo C.struct_file_dedupe_range_info
 const (
 	SizeofRawFileDedupeRange     = C.sizeof_struct_file_dedupe_range
 	SizeofRawFileDedupeRangeInfo = C.sizeof_struct_file_dedupe_range_info
+	FILE_DEDUPE_RANGE_SAME       = C.FILE_DEDUPE_RANGE_SAME
+	FILE_DEDUPE_RANGE_DIFFERS    = C.FILE_DEDUPE_RANGE_DIFFERS
 )
 
 // Filesystem Encryption

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -185,8 +185,11 @@ func IoctlFileDedupeRange(srcFd int, value *FileDedupeRange) error {
 		rawinfo := (*RawFileDedupeRangeInfo)(unsafe.Pointer(
 			uintptr(unsafe.Pointer(&buf[0])) + uintptr(SizeofRawFileDedupeRange) +
 				uintptr(i*SizeofRawFileDedupeRangeInfo)))
+		value.Info[i].Dest_fd = rawinfo.Dest_fd
+		value.Info[i].Dest_offset = rawinfo.Dest_offset
 		value.Info[i].Bytes_deduped = rawinfo.Bytes_deduped
 		value.Info[i].Status = rawinfo.Status
+		value.Info[i].Reserved = rawinfo.Reserved
 	}
 
 	return err

--- a/unix/syscall_linux.go
+++ b/unix/syscall_linux.go
@@ -137,12 +137,49 @@ func IoctlFileClone(destFd, srcFd int) error {
 	return ioctl(destFd, FICLONE, uintptr(srcFd))
 }
 
+type FileDedupeRange struct {
+	Src_offset uint64
+	Src_length uint64
+	Dest_count uint16
+	Reserved1  uint16
+	Reserved2  uint32
+	Info       []FileDedupeRangeInfo
+}
+
+type FileDedupeRangeInfo struct {
+	Dest_fd       int64
+	Dest_offset   uint64
+	Bytes_deduped uint64
+	Status        int32
+	Reserved      uint32
+}
+
 // IoctlFileDedupeRange performs an FIDEDUPERANGE ioctl operation to share the
 // range of data conveyed in value with the file associated with the file
 // descriptor destFd. See the ioctl_fideduperange(2) man page for details.
-func IoctlFileDedupeRange(destFd int, value *FileDedupeRange) error {
-	err := ioctl(destFd, FIDEDUPERANGE, uintptr(unsafe.Pointer(value)))
-	runtime.KeepAlive(value)
+func IoctlFileDedupeRange(srcFd int, value *FileDedupeRange) error {
+	buf := make([]byte, SizeofRawFileDedupeRange+
+		len(value.Info)*SizeofRawFileDedupeRangeInfo)
+	rawrange := (*FileDedupeRange)(unsafe.Pointer(&buf[0]))
+	rawrange.Src_offset = value.Src_offset
+	rawrange.Src_length = value.Src_length
+	rawrange.Dest_count = uint16(len(value.Info))
+	rawrange.Reserved1 = value.Reserved1
+	rawrange.Reserved2 = value.Reserved2
+
+	for i := range value.Info {
+		rawinfo := (*RawFileDedupeRangeInfo)(unsafe.Pointer(
+			uintptr(unsafe.Pointer(&buf[0])) + uintptr(SizeofRawFileDedupeRange) +
+				uintptr(SizeofRawFileDedupeRangeInfo)))
+		rawinfo.Dest_fd = value.Info[i].Dest_fd
+		rawinfo.Dest_offset = value.Info[i].Dest_offset
+		rawinfo.Bytes_deduped = value.Info[i].Bytes_deduped
+		rawinfo.Status = value.Info[i].Status
+		rawinfo.Reserved = value.Info[i].Reserved
+	}
+
+	err := ioctl(srcFd, FIDEDUPERANGE, uintptr(unsafe.Pointer(&buf[0])))
+	runtime.KeepAlive(buf)
 	return err
 }
 

--- a/unix/syscall_linux_test.go
+++ b/unix/syscall_linux_test.go
@@ -839,12 +839,10 @@ func TestFideduperange(t *testing.T) {
 			unix.FileDedupeRangeInfo{
 			  Dest_fd: int64(f2.Fd()),
 				Dest_offset: uint64(0),
-				Bytes_deduped: uint64(4096),
 			},
 			unix.FileDedupeRangeInfo{
 			  Dest_fd: int64(f2.Fd()),
 				Dest_offset: uint64(4096),
-				Bytes_deduped: uint64(4096),
 			},
 		}}
 

--- a/unix/syscall_linux_test.go
+++ b/unix/syscall_linux_test.go
@@ -802,6 +802,7 @@ func TestFideduperange(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f1.Close()
+	defer os.Remove(f1.Name())
 
 	for i := 0; i < 2; i += 1 {
 		_, err = f1.Write(make([]byte, 4096))
@@ -815,6 +816,7 @@ func TestFideduperange(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f2.Close()
+	defer os.Remove(f2.Name())
 
 	for i := 0; i < 2; i += 1 {
 		data := make([]byte, 4096)

--- a/unix/syscall_linux_test.go
+++ b/unix/syscall_linux_test.go
@@ -800,7 +800,7 @@ func TestFideduperange(t *testing.T) {
 	if runtime.GOOS == "android" {
 		// The ioctl in the build robot android-amd64 returned ENOTTY,
 		// an error not documented for that syscall.
-		t.Skip("FIDEDUPERANGE ioctl doesn't work the test android, skipping test")
+		t.Skip("FIDEDUPERANGE ioctl doesn't work on android, skipping test")
 	}
 
 	f1, err := ioutil.TempFile("", t.Name())

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -102,6 +102,8 @@ type RawFileDedupeRangeInfo struct {
 const (
 	SizeofRawFileDedupeRange     = 0x18
 	SizeofRawFileDedupeRangeInfo = 0x20
+	FILE_DEDUPE_RANGE_SAME       = 0x0
+	FILE_DEDUPE_RANGE_DIFFERS    = 0x1
 )
 
 type FscryptPolicy struct {

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -83,13 +83,26 @@ type FileCloneRange struct {
 	Dest_offset uint64
 }
 
-type FileDedupeRange struct {
+type RawFileDedupeRange struct {
 	Src_offset uint64
 	Src_length uint64
 	Dest_count uint16
 	Reserved1  uint16
 	Reserved2  uint32
 }
+
+type RawFileDedupeRangeInfo struct {
+	Dest_fd       int64
+	Dest_offset   uint64
+	Bytes_deduped uint64
+	Status        int32
+	Reserved      uint32
+}
+
+const (
+	SizeofRawFileDedupeRange     = 0x18
+	SizeofRawFileDedupeRangeInfo = 0x20
+)
 
 type FscryptPolicy struct {
 	Version                   uint8


### PR DESCRIPTION
The previous implementation didn't match the ioctl spec.

Fixes golang/go#43678