### PR TITLE
Windows: Added ReadConsoleInput functionality

### DIFF
--- a/windows/input_record.go
+++ b/windows/input_record.go
@@ -1,0 +1,33 @@
+package windows
+
+// InputRecord is the data structure that ReadConsoleInput writes into.
+// See: https://docs.microsoft.com/en-us/windows/console/input-record-str
+type InputRecord struct {
+	// Type can be one of the following:
+	// 0x1: The event is of type KEY_EVENT: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+	// 0x2: The event is of type MOUSE_EVENT and will never be read when using ReadConsoleInput
+	// 0x4: The event is of type WINDOW_BUFFER_SIZE_EVENT: https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str
+	// 0x8: The event is of type MENU_EVENT and should be ignored.
+	// 0x10: The event is of type FOCUS_EVENT: https://docs.microsoft.com/en-us/windows/console/focus-event-record-str
+	Type  uint16
+	_ [2]byte // discard the next two bytes
+
+	// Event contents can be one of:
+	// KEY_EVENT (Type == 1)
+	//  - Event[0] is 0x1 if the key is pressed, 0x0 if the key is released
+	//  - Event[1] and Event[2] is random garbage
+	//  - Event[3] is the keycode of the pressed key. The numbers are completely different
+	//    to normal ASCII keycode, see
+	//    https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+	//  - Event[4] is the keyboard scan code.
+	//  - Event[5] contains the typed ascii or Unicode (not UTF8!!) keycode.
+	//    from 0x20 through 0x7f they are equal
+	//  - Event[6] stores the state of the modifier keys. See https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+	// WINDOW_BUFFER_SIZE_EVENT (TYPE == 4)
+	//  - Event[0] is the new amount of character rows
+	//  - Event[1] is the new amount of character columns
+	// FOCUS_EVENT (Type == 16)
+	//  - Event[0] is 0x1 if the window is now focused and 0x0 if the window is now unfocused
+	Event [6]uint16
+}
+

--- a/windows/input_record.go
+++ b/windows/input_record.go
@@ -10,7 +10,7 @@ type InputRecord struct {
 	// 0x8: The event is of type MENU_EVENT and should be ignored.
 	// 0x10: The event is of type FOCUS_EVENT and should be ignored.
 	Type  uint16
-	_ [2]byte // discard the next two bytes
+	_     [2]byte // discard the next two bytes
 
 	// Event contents can be one of:
 	// KEY_EVENT (Type == 1)

--- a/windows/input_record.go
+++ b/windows/input_record.go
@@ -1,14 +1,14 @@
 package windows
 
 // InputRecord is the data structure that ReadConsoleInput writes into.
-// See: https://docs.microsoft.com/en-us/windows/console/input-record-str
+// Original source: https://docs.microsoft.com/en-us/windows/console/input-record-str
 type InputRecord struct {
-	// Original source: https://docs.microsoft.com/en-us/windows/console/input-record-str#members
 	// 0x1: Key event
 	// 0x2: Will never be read when using ReadConsoleInput
 	// 0x4: Window buffer size event
 	// 0x8: Deprecated
 	// 0x10: Deprecated
+	// Original source: https://docs.microsoft.com/en-us/windows/console/input-record-str#members
 	Type  uint16
 	_     [2]byte // discard the next two bytes
 
@@ -19,11 +19,12 @@ type InputRecord struct {
 	//    https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 	//  - Event[5] is the ascii or Unicode keycode.
 	//  - Event[6] stores the state of the modifier keys.
-	//    See https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+	//  Original source: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
 	// 
 	// WINDOW_BUFFER_SIZE_EVENT (TYPE == 4)
 	//  - Event[0] is the new amount of character rows
 	//  - Event[1] is the new amount of character columns
+	// Original source: https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str
 	Event [6]uint16
 }
 

--- a/windows/input_record.go
+++ b/windows/input_record.go
@@ -1,7 +1,9 @@
 package windows
 
 // InputRecord is the data structure that ReadConsoleInput writes into.
-// Original source: https://docs.microsoft.com/en-us/windows/console/input-record-str
+// All Documentation originally provided by Michael Niksa, et al. at Microsoft Corporation
+// under CC Attribution 4.0 International
+// via https://docs.microsoft.com/en-us/windows/console/input-record-str
 type InputRecord struct {
 	// 0x1: Key event
 	// 0x2: Will never be read when using ReadConsoleInput

--- a/windows/input_record.go
+++ b/windows/input_record.go
@@ -8,7 +8,7 @@ type InputRecord struct {
 	// 0x2: The event is of type MOUSE_EVENT and will never be read when using ReadConsoleInput
 	// 0x4: The event is of type WINDOW_BUFFER_SIZE_EVENT: https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str
 	// 0x8: The event is of type MENU_EVENT and should be ignored.
-	// 0x10: The event is of type FOCUS_EVENT: https://docs.microsoft.com/en-us/windows/console/focus-event-record-str
+	// 0x10: The event is of type FOCUS_EVENT and should be ignored.
 	Type  uint16
 	_ [2]byte // discard the next two bytes
 
@@ -26,8 +26,6 @@ type InputRecord struct {
 	// WINDOW_BUFFER_SIZE_EVENT (TYPE == 4)
 	//  - Event[0] is the new amount of character rows
 	//  - Event[1] is the new amount of character columns
-	// FOCUS_EVENT (Type == 16)
-	//  - Event[0] is 0x1 if the window is now focused and 0x0 if the window is now unfocused
 	Event [6]uint16
 }
 

--- a/windows/input_record.go
+++ b/windows/input_record.go
@@ -3,26 +3,24 @@ package windows
 // InputRecord is the data structure that ReadConsoleInput writes into.
 // See: https://docs.microsoft.com/en-us/windows/console/input-record-str
 type InputRecord struct {
-	// Type can be one of the following:
-	// 0x1: The event is of type KEY_EVENT: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
-	// 0x2: The event is of type MOUSE_EVENT and will never be read when using ReadConsoleInput
-	// 0x4: The event is of type WINDOW_BUFFER_SIZE_EVENT: https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str
-	// 0x8: The event is of type MENU_EVENT and should be ignored.
-	// 0x10: The event is of type FOCUS_EVENT and should be ignored.
+	// Original source: https://docs.microsoft.com/en-us/windows/console/input-record-str#members
+	// 0x1: Key event
+	// 0x2: Will never be read when using ReadConsoleInput
+	// 0x4: Window buffer size event
+	// 0x8: Deprecated
+	// 0x10: Deprecated
 	Type  uint16
 	_     [2]byte // discard the next two bytes
 
 	// Event contents can be one of:
 	// KEY_EVENT (Type == 1)
 	//  - Event[0] is 0x1 if the key is pressed, 0x0 if the key is released
-	//  - Event[1] and Event[2] is random garbage
-	//  - Event[3] is the keycode of the pressed key. The numbers are completely different
-	//    to normal ASCII keycode, see
+	//  - Event[3] is the keycode of the pressed key, see
 	//    https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-	//  - Event[4] is the keyboard scan code.
-	//  - Event[5] contains the typed ascii or Unicode (not UTF8!!) keycode.
-	//    from 0x20 through 0x7f they are equal
-	//  - Event[6] stores the state of the modifier keys. See https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+	//  - Event[5] is the ascii or Unicode keycode.
+	//  - Event[6] stores the state of the modifier keys.
+	//    See https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+	// 
 	// WINDOW_BUFFER_SIZE_EVENT (TYPE == 4)
 	//  - Event[0] is the new amount of character rows
 	//  - Event[1] is the new amount of character columns

--- a/windows/input_record.go
+++ b/windows/input_record.go
@@ -14,19 +14,19 @@ type InputRecord struct {
 	Type  uint16
 	_     [2]byte // discard the next two bytes
 
-	// Event contents can be one of:
-	// KEY_EVENT (Type == 1)
-	//  - Event[0] is 0x1 if the key is pressed, 0x0 if the key is released
-	//  - Event[3] is the keycode of the pressed key, see
+	// Data contents are:
+	// If the event is a key event (Type == 1):
+	//  - Data[0] is 0x1 if the key is pressed, 0x0 if the key is released
+	//  - Data[3] is the keycode of the pressed key, see
 	//    https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-	//  - Event[5] is the ascii or Unicode keycode.
-	//  - Event[6] stores the state of the modifier keys.
+	//  - Data[5] is the ascii or Unicode keycode.
+	//  - Data[6] stores the state of the modifier keys.
 	//  Original source: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
 	// 
-	// WINDOW_BUFFER_SIZE_EVENT (TYPE == 4)
-	//  - Event[0] is the new amount of character rows
-	//  - Event[1] is the new amount of character columns
+	// If the event is a window buffer size event (Type == 4):
+	//  - Data[0] is the new amount of character rows
+	//  - Data[1] is the new amount of character columns
 	// Original source: https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str
-	Event [6]uint16
+	Data [6]uint16
 }
 

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -2440,7 +2440,7 @@ func ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, input
 // The data is read into the array starting at buf.
 // toread is the amount of keypresses that should be read.
 // The actual amount of keypresses read is stored in read.
-// The differenc between ReadConsole and ReadConsoleInput is that 
+// The difference between ReadConsole and ReadConsoleInput is that 
 //  - ReadConsole only reads character insertion (reads any character key pressed)
 //  - ReadConsoleInput reads any key (both key press and key release) as well as mouse, focus and window size change events
 // See: https://docs.microsoft.com/en-us/windows/console/readconsoleinput

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -2436,41 +2436,13 @@ func ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, input
 	return
 }
 
-// InputRecord is the data structure that ReadConsoleInput writes into.
-// See: https://docs.microsoft.com/en-us/windows/console/input-record-str
-type InputRecord struct {
-	// Type can be one of the following:
-	// 0x1: The event is of type KEY_EVENT: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
-	// 0x2: The event is of type MOUSE_EVENT and will never be read when using ReadConsoleInput
-	// 0x4: The event is of type WINDOW_BUFFER_SIZE_EVENT: https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str
-	// 0x8: The event is of type MENU_EVENT and should be ignored.
-	// 0x10: The event is of type FOCUS_EVENT: https://docs.microsoft.com/en-us/windows/console/focus-event-record-str
-	Type  uint16
-	_ [2]byte // discard the next two bytes
-
-	// Event contents can be one of:
-	// KEY_EVENT (Type == 1)
-	//  - Event[0] is 0x1 if the key is pressed, 0x0 if the key is released
-	//  - Event[1] and Event[2] is random garbage
-	//  - Event[3] is the keycode of the pressed key. The numbers are completely different
-	//    to normal ASCII keycode, see
-	//    https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-	//  - Event[4] is the keyboard scan code.
-	//  - Event[5] contains the typed ascii or Unicode (not UTF8!!) keycode.
-	//    from 0x20 through 0x7f they are equal
-	//  - Event[6] stores the state of the modifier keys. See https://docs.microsoft.com/en-us/windows/console/key-event-record-str
-	// WINDOW_BUFFER_SIZE_EVENT (TYPE == 4)
-	//  - Event[0] is the new amount of character rows
-	//  - Event[1] is the new amount of character columns
-	// FOCUS_EVENT (Type == 16)
-	//  - Event[0] is 0x1 if the window is now focused and 0x0 if the window is now unfocused
-	Event [6]uint16
-}
-
 // ReadConsoleInput reads keypresses from console.
 // The data is read into the array starting at buf.
 // toread is the amount of keypresses that should be read.
 // The actual amount of keypresses read is stored in read.
+// The differenc between ReadConsole and ReadConsoleInput is that 
+//  - ReadConsole only reads character insertion (reads any character key pressed)
+//  - ReadConsoleInput reads any key (both key press and key release) as well as mouse, focus and window size change events
 func ReadConsoleInput(console Handle, rec *InputRecord, toread uint32, read *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procReadConsoleInputW.Addr(), 4,
 		uintptr(console), uintptr(unsafe.Pointer(rec)), uintptr(toread),

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -2443,6 +2443,7 @@ func ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, input
 // The differenc between ReadConsole and ReadConsoleInput is that 
 //  - ReadConsole only reads character insertion (reads any character key pressed)
 //  - ReadConsoleInput reads any key (both key press and key release) as well as mouse, focus and window size change events
+// See: https://docs.microsoft.com/en-us/windows/console/readconsoleinput
 func ReadConsoleInput(console Handle, rec *InputRecord, toread uint32, read *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procReadConsoleInputW.Addr(), 4,
 		uintptr(console), uintptr(unsafe.Pointer(rec)), uintptr(toread),

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -285,6 +285,7 @@ var (
 	procQueryDosDeviceW                                      = modkernel32.NewProc("QueryDosDeviceW")
 	procQueryInformationJobObject                            = modkernel32.NewProc("QueryInformationJobObject")
 	procReadConsoleW                                         = modkernel32.NewProc("ReadConsoleW")
+	procReadConsoleInputW                                    = modkernel32.NewProc("ReadConsoleInputW")
 	procReadDirectoryChangesW                                = modkernel32.NewProc("ReadDirectoryChangesW")
 	procReadFile                                             = modkernel32.NewProc("ReadFile")
 	procReleaseMutex                                         = modkernel32.NewProc("ReleaseMutex")
@@ -2426,8 +2427,54 @@ func QueryInformationJobObject(job Handle, JobObjectInformationClass int32, JobO
 // toread specifies how many characters should be read
 // read should point to a uint32 where the number of characters actually read should be stored
 // inputControl should be set to NULL, as it currently has no effect
+// See: https://docs.microsoft.com/en-us/windows/console/readconsole
 func ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) {
 	r1, _, e1 := syscall.Syscall6(procReadConsoleW.Addr(), 5, uintptr(console), uintptr(unsafe.Pointer(buf)), uintptr(toread), uintptr(unsafe.Pointer(read)), uintptr(unsafe.Pointer(inputControl)), 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+// InputRecord is the data structure that ReadConsoleInput writes into.
+// See: https://docs.microsoft.com/en-us/windows/console/input-record-str
+type InputRecord struct {
+	// Type can be one of the following:
+	// 0x1: The event is of type KEY_EVENT: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+	// 0x2: The event is of type MOUSE_EVENT and will never be read when using ReadConsoleInput
+	// 0x4: The event is of type WINDOW_BUFFER_SIZE_EVENT: https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str
+	// 0x8: The event is of type MENU_EVENT and should be ignored.
+	// 0x10: The event is of type FOCUS_EVENT: https://docs.microsoft.com/en-us/windows/console/focus-event-record-str
+	Type  uint16
+	_ [2]byte // discard the next two bytes
+
+	// Event contents can be one of:
+	// KEY_EVENT (Type == 1)
+	//  - Event[0] is 0x1 if the key is pressed, 0x0 if the key is released
+	//  - Event[1] and Event[2] is random garbage
+	//  - Event[3] is the keycode of the pressed key. The numbers are completely different
+	//    to normal ASCII keycode, see
+	//    https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+	//  - Event[4] is the keyboard scan code.
+	//  - Event[5] contains the typed ascii or Unicode (not UTF8!!) keycode.
+	//    from 0x20 through 0x7f they are equal
+	//  - Event[6] stores the state of the modifier keys. See https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+	// WINDOW_BUFFER_SIZE_EVENT (TYPE == 4)
+	//  - Event[0] is the new amount of character rows
+	//  - Event[1] is the new amount of character columns
+	// FOCUS_EVENT (Type == 16)
+	//  - Event[0] is 0x1 if the window is now focused and 0x0 if the window is now unfocused
+	Event [6]uint16
+}
+
+// ReadConsoleInput reads keypresses from console.
+// The data is read into the array starting at buf.
+// toread is the amount of keypresses that should be read.
+// The actual amount of keypresses read is stored in read.
+func ReadConsoleInput(console Handle, rec *InputRecord, toread uint32, read *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procReadConsoleInputW.Addr(), 4,
+		uintptr(console), uintptr(unsafe.Pointer(rec)), uintptr(toread),
+		uintptr(unsafe.Pointer(read)), 0, 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -2421,6 +2421,11 @@ func QueryInformationJobObject(job Handle, JobObjectInformationClass int32, JobO
 	return
 }
 
+// ReadConsole reads characters from the console and writes the Unicode keycode(s) into buf
+// buf should point to the element in an array where writing should begin
+// toread specifies how many characters should be read
+// read should point to a uint32 where the number of characters actually read should be stored
+// inputControl should be set to NULL, as it currently has no effect
 func ReadConsole(console Handle, buf *uint16, toread uint32, read *uint32, inputControl *byte) (err error) {
 	r1, _, e1 := syscall.Syscall6(procReadConsoleW.Addr(), 5, uintptr(console), uintptr(unsafe.Pointer(buf)), uintptr(toread), uintptr(unsafe.Pointer(read)), uintptr(unsafe.Pointer(inputControl)), 0)
 	if r1 == 0 {


### PR DESCRIPTION
Hello.
I recently opened an issue on the main repository: https://github.com/golang/go/issues/44373, where I was wondering whether there was a way to read special keys on Windows. After some investigation I came up with this change.

## Motivation
 - Go, especially the `x/sys/windows`, provides wrappers for many C functions that are exposed by the windows console api. The `ReadConsole()` function for example can read single characters from the console.
 - The Windows Console API also provides a C function for reading special keys from the console (think arrow keys, e.g.). There is currently no wrapper function for this one in `x/sys/windows`.
 - As of today, there are two big Go libraries that need this exact functionality: reading special keys from the console - [termbox-go](https://github.com/nsf/termbox-go)* (4k stars) and [tcell](https://github.com/gdamore/tcell) (2.6k stars).
Both libraries currently use the `syscall` package (which has been deprecated for ages now) for reading from the console on Windows.

\* DISCLAIMER: I am a maintainer of `termbox-go`.

## Background

On Linux, any key can be read from the console using only `x/sys/unix` by setting the termios to raw mode and reading using `unix.Read(Handle, []byte)`.

On Windows, the `x/sys/windows` package also provides means to get and set the console mode (comparable to termios).
However, the provided `ReadConsole()` functionality does only read characters, it does not read special keys (arrow keys, F1 through F12, Home/End, PgUp/PgDn, Delete/Erase).

If a Windows *C* developer wants to read special keys, they can use the [`ReadConsoleInput()`](https://docs.microsoft.com/en-us/windows/console/readconsoleinput) instead of [`ReadConsole()`](https://docs.microsoft.com/en-us/windows/console/readconsole). `ReadConsole()` only reads characters from the console, while `ReadConsoleInput()` reads almost every event type (key press, key release, special keys, window size change, ...).

## Implementation

### ReadConsoleInput

I implemented the `ReadConsoleInput` function which works like the original `ReadConsole()` function. The implementation simply calls Windows's `ReadConsoleInputW` function.

The difference in parameters passed is taken care of:

ReadConsole takes a Handle, pointer to a buffer, number of characters to read, pointer to storage for the amount of total read characters and pointer to an InputControl while ReadConsoleinput takes a Handle, pointer to a buffer, buffer length, pointer to a storage for the amount of total read characters.

The first four parameters are comparable, except for the buffer type. The last (optional) parameter does not apply to `ReadConsoleInput` (`nargs` argument of the syscall is 4 instead of 5).

### InputRecord

However, the `ReadConsoleInput()` function reads one or multiple `INPUT_RECORD`s, see https://docs.microsoft.com/en-us/windows/console/input-record-str.
So I added a new type, called `InputRecord` which represents Windows's original type.
`ReadConsoleInput()` reads into a pointer to an `InputRecord`. 

## Problems

There were some inconsistencies during my testing:
 - I couldn't get `ReadConsoleInput()` to read multiple records. I tried setting the `toread` to more than 1 and
     - passing a pointer to a `[]InputRecord` to the syscall
     - passing a pointer to the first value of a `[]InputRecord` to the syscall
both times, only the first entry was written
 - `ReadConsoleInput()` would very rarely segfault if they key was held down after all data was read.
The error was something along of `unknown pc reported`, though I can't reproduce it after I've changed some internals (changed the `nargs` parameter to 4 instead of 5).

Here's a testing file I used during development if anyone wants to investigate the implementation details further:
[input_test.txt](https://github.com/golang/sys/files/6009178/input_test.txt)

I won't add it to the tree since it's not a Unit test but an interactive test.

### ReadConsole InputControl

I also took a look at the `ReadConsole()` functionality. The Windows version optionally takes as a last argument a pointer to a [CONSOLE_READCONSOLE_CONTROL](https://docs.microsoft.com/en-us/windows/console/console-readconsole-control) struct. You can see that I recreated this struct in my testing file.

I tried to use it - the Windows API marks it as optional input. I would expect
 - setting the `nInitialChars` member to a value greater than 0 would retain the first value(s) in the supplied array. It did not.
 - the `dwControlKeyState` to be set after the call to `ReadConsole()`. It was not.

Any usage of `ReadConsole()` I could find out there did simply use 0 as an inputControl value so I sticked with that.

`ReadConsole()` returns an array of `TCHAR` which can be represented in Go using a `[]byte` which in turn can be converted into a `[]rune`, so that parameter to the already existing `ReadConsole()` function makes sense as-is.

### Auto-generated code
A disclaimer at the top of `zsyscall_windows.go` says it is auto-generated. I couldn't find any documentation how that generation works, and no template file either, so I added my code manually.
Maybe it has to be included in some template file.

### Documentation
As the code is auto-generated it does not feature any documentation.
However, both `ReadConsole()` and `ReadConsoleInput()` are not self-explanatory (especially the difference between the two).
I added documentation for both functions as well as my newly added struct.

### Copyright

The content of the documentation is orginally [provided by Microsoft](https://github.com/MicrosoftDocs/Console-Docs), licensed under [CC Attribution 4.0 International](https://github.com/MicrosoftDocs/Console-Docs/blob/master/LICENSE).

I don't know anything about licensing, I just want people to understand my code. I added Copyright disclaimers to a reasonable extent, but maybe it's better to strip all documentation and only link to Microsoft's original documentation?

The same problem applies to the definition of the `InputRecord` struct - does my definition infringe Microsoft's intellectual property? It is originally defined in `WinConTypes.h`.

In case this (partly) gets merged I really want to advise squashing the whole changeset because there are many testing iterations in between.

Thanks for your time.