### PR TITLE
windows: add "minimum Windows version" helpers.

### DIFF
--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -180,6 +180,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 //sys	ExitProcess(exitcode uint32)
 //sys	IsWow64Process(handle Handle, isWow64 *bool) (err error) = IsWow64Process
 //sys	IsWow64Process2(handle Handle, processMachine *uint16, nativeMachine *uint16) (err error) = IsWow64Process2?
+//sys	IsWindowsVersionOrGreater(major uint16, minor uint16, sp uint16) (gt bool)
+//sys	IsWindowsServer() (t bool)
 //sys	CreateFile(name *uint16, access uint32, mode uint32, sa *SecurityAttributes, createmode uint32, attrs uint32, templatefile Handle) (handle Handle, err error) [failretval==InvalidHandle] = CreateFileW
 //sys	CreateNamedPipe(name *uint16, flags uint32, pipeMode uint32, maxInstances uint32, outSize uint32, inSize uint32, defaultTimeout uint32, sa *SecurityAttributes) (handle Handle, err error)  [failretval==InvalidHandle] = CreateNamedPipeW
 //sys	ConnectNamedPipe(pipe Handle, overlapped *Overlapped) (err error)
@@ -414,6 +416,18 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 //sys	NtSetInformationProcess(proc Handle, procInfoClass int32, procInfo unsafe.Pointer, procInfoLen uint32) (ntstatus error) = ntdll.NtSetInformationProcess
 
 // syscall interface implementation for other packages
+
+// Version helpers, reimplemented in Go over the base
+// IsWindowsVersionOrGreater rather than call out to the helpers
+// defined in the DLL. That way, all the helpers are available
+// regardless of the Windows version, instead of functions
+// mysteriously disappearing when running on older Windows.
+
+func IsWindows10OrGreater() bool      { return IsWindowsVersionOrGreater(10, 0, 0) }
+func IsWindows8Point1OrGreater() bool { return IsWindowsVersionOrGreater(6, 3, 0) }
+func IsWindows8OrGreater() bool       { return IsWindowsVersionOrGreater(6, 2, 0) }
+func IsWindows7SP1OrGreater() bool    { return IsWindowsVersionOrGreater(6, 1, 1) }
+func IsWindows7OrGreater() bool       { return IsWindowsVersionOrGreater(6, 1, 0) }
 
 // GetCurrentProcess returns the handle for the current process.
 // It is a pseudo handle that does not need to be closed.

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -274,6 +274,8 @@ var (
 	procGetVolumePathNamesForVolumeNameW                     = modkernel32.NewProc("GetVolumePathNamesForVolumeNameW")
 	procGetWindowsDirectoryW                                 = modkernel32.NewProc("GetWindowsDirectoryW")
 	procInitializeProcThreadAttributeList                    = modkernel32.NewProc("InitializeProcThreadAttributeList")
+	procIsWindowsServer                                      = modkernel32.NewProc("IsWindowsServer")
+	procIsWindowsVersionOrGreater                            = modkernel32.NewProc("IsWindowsVersionOrGreater")
 	procIsWow64Process                                       = modkernel32.NewProc("IsWow64Process")
 	procIsWow64Process2                                      = modkernel32.NewProc("IsWow64Process2")
 	procLoadLibraryExW                                       = modkernel32.NewProc("LoadLibraryExW")
@@ -2326,6 +2328,18 @@ func initializeProcThreadAttributeList(attrlist *ProcThreadAttributeList, attrco
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
+	return
+}
+
+func IsWindowsServer() (t bool) {
+	r0, _, _ := syscall.Syscall(procIsWindowsServer.Addr(), 0, 0, 0, 0)
+	t = r0 != 0
+	return
+}
+
+func IsWindowsVersionOrGreater(major uint16, minor uint16, sp uint16) (gt bool) {
+	r0, _, _ := syscall.Syscall(procIsWindowsVersionOrGreater.Addr(), 3, uintptr(major), uintptr(minor), uintptr(sp))
+	gt = r0 != 0
 	return
 }
 


### PR DESCRIPTION
These helpers let programs probe the Windows version at runtime, to
enable feature gates or compatibility shims.

Signed-off-by: David Anderson <danderson@tailscale.com>

---

Rationale: I need to detect Windows 7 to enable compat hacks that work around the absence of per-domain DNS routing. The Windows documentation advises to do this via these version helpers.

Originally, I only implemented IsWindowsVersionOrGreater, but the version numbers you have to pass in are the API numbers, which have almost no relation to the marketing version (e.g. Windows 8 is version 6.2, Windows 7 SP1 is version 6.1.1), so I also added the helpers that use the well-known release names.

I only implemented helpers going as far back as Go supports, rather than all the way back to IsWindowsXPOrGreater (which, of course, is version 5.1), since the latter would always return true on any Windows capable of running Go binaries. Happy to add them in as well though if there's a chance gccgo or gollvm might work on those older versions.