### PR TITLE
unix: add SEEK_* constants on Darwin, FreeBSD, Linux

### DIFF
--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -563,6 +563,7 @@ ccflags="$@"
 		$2 ~ /^KEYCTL_/ ||
 		$2 ~ /^PERF_/ ||
 		$2 ~ /^SECCOMP_MODE_/ ||
+		$2 ~ /^SEEK_/ ||
 		$2 ~ /^SPLICE_/ ||
 		$2 ~ /^SYNC_FILE_RANGE_/ ||
 		$2 !~ /^AUDIT_RECORD_MAGIC/ &&

--- a/unix/zerrors_darwin_amd64.go
+++ b/unix/zerrors_darwin_amd64.go
@@ -1262,6 +1262,11 @@ const (
 	SCM_RIGHTS                        = 0x1
 	SCM_TIMESTAMP                     = 0x2
 	SCM_TIMESTAMP_MONOTONIC           = 0x4
+	SEEK_CUR                          = 0x1
+	SEEK_DATA                         = 0x4
+	SEEK_END                          = 0x2
+	SEEK_HOLE                         = 0x3
+	SEEK_SET                          = 0x0
 	SHUT_RD                           = 0x0
 	SHUT_RDWR                         = 0x2
 	SHUT_WR                           = 0x1

--- a/unix/zerrors_darwin_arm64.go
+++ b/unix/zerrors_darwin_arm64.go
@@ -1262,6 +1262,11 @@ const (
 	SCM_RIGHTS                        = 0x1
 	SCM_TIMESTAMP                     = 0x2
 	SCM_TIMESTAMP_MONOTONIC           = 0x4
+	SEEK_CUR                          = 0x1
+	SEEK_DATA                         = 0x4
+	SEEK_END                          = 0x2
+	SEEK_HOLE                         = 0x3
+	SEEK_SET                          = 0x0
 	SHUT_RD                           = 0x0
 	SHUT_RDWR                         = 0x2
 	SHUT_WR                           = 0x1

--- a/unix/zerrors_freebsd_386.go
+++ b/unix/zerrors_freebsd_386.go
@@ -1297,6 +1297,11 @@ const (
 	SCM_RIGHTS                     = 0x1
 	SCM_TIMESTAMP                  = 0x2
 	SCM_TIME_INFO                  = 0x7
+	SEEK_CUR                       = 0x1
+	SEEK_DATA                      = 0x3
+	SEEK_END                       = 0x2
+	SEEK_HOLE                      = 0x4
+	SEEK_SET                       = 0x0
 	SHUT_RD                        = 0x0
 	SHUT_RDWR                      = 0x2
 	SHUT_WR                        = 0x1

--- a/unix/zerrors_freebsd_amd64.go
+++ b/unix/zerrors_freebsd_amd64.go
@@ -1298,6 +1298,11 @@ const (
 	SCM_RIGHTS                     = 0x1
 	SCM_TIMESTAMP                  = 0x2
 	SCM_TIME_INFO                  = 0x7
+	SEEK_CUR                       = 0x1
+	SEEK_DATA                      = 0x3
+	SEEK_END                       = 0x2
+	SEEK_HOLE                      = 0x4
+	SEEK_SET                       = 0x0
 	SHUT_RD                        = 0x0
 	SHUT_RDWR                      = 0x2
 	SHUT_WR                        = 0x1

--- a/unix/zerrors_freebsd_arm.go
+++ b/unix/zerrors_freebsd_arm.go
@@ -1276,6 +1276,11 @@ const (
 	SCM_CREDS                      = 0x3
 	SCM_RIGHTS                     = 0x1
 	SCM_TIMESTAMP                  = 0x2
+	SEEK_CUR                       = 0x1
+	SEEK_DATA                      = 0x3
+	SEEK_END                       = 0x2
+	SEEK_HOLE                      = 0x4
+	SEEK_SET                       = 0x0
 	SHUT_RD                        = 0x0
 	SHUT_RDWR                      = 0x2
 	SHUT_WR                        = 0x1

--- a/unix/zerrors_freebsd_arm64.go
+++ b/unix/zerrors_freebsd_arm64.go
@@ -1298,6 +1298,11 @@ const (
 	SCM_RIGHTS                     = 0x1
 	SCM_TIMESTAMP                  = 0x2
 	SCM_TIME_INFO                  = 0x7
+	SEEK_CUR                       = 0x1
+	SEEK_DATA                      = 0x3
+	SEEK_END                       = 0x2
+	SEEK_HOLE                      = 0x4
+	SEEK_SET                       = 0x0
 	SHUT_RD                        = 0x0
 	SHUT_RDWR                      = 0x2
 	SHUT_WR                        = 0x1

--- a/unix/zerrors_linux.go
+++ b/unix/zerrors_linux.go
@@ -2284,6 +2284,12 @@ const (
 	SECCOMP_MODE_FILTER                         = 0x2
 	SECCOMP_MODE_STRICT                         = 0x1
 	SECURITYFS_MAGIC                            = 0x73636673
+	SEEK_CUR                                    = 0x1
+	SEEK_DATA                                   = 0x3
+	SEEK_END                                    = 0x2
+	SEEK_HOLE                                   = 0x4
+	SEEK_MAX                                    = 0x4
+	SEEK_SET                                    = 0x0
 	SELINUX_MAGIC                               = 0xf97cff8c
 	SHUT_RD                                     = 0x0
 	SHUT_RDWR                                   = 0x2


### PR DESCRIPTION
The Go "os" package already provides bindings for SEEK_CUR, SEEK_SET and
SEEK_END. Most operating systems also support SEEK_HOLE and SEEK_DATA,
which you can use to skip sparse regions in a file. Let's add bindings,
so we can also do this from within Go.