### PR TITLE
unix: Add SO_REUSEPORT definition for Solaris.

### DIFF
--- a/unix/zerrors_solaris_amd64.go
+++ b/unix/zerrors_solaris_amd64.go
@@ -1005,6 +1005,7 @@ const (
 	SO_READOPT                    = 0x1
 	SO_RECVUCRED                  = 0x400
 	SO_REUSEADDR                  = 0x4
+	SO_REUSEPORT                  = 0x2004
 	SO_SECATTR                    = 0x1011
 	SO_SNDBUF                     = 0x1001
 	SO_SNDLOWAT                   = 0x1003


### PR DESCRIPTION
This adds SO_REUSEPORT for Solaris.