### PR TITLE
windows: add process module related syscalls

### DIFF
--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -398,6 +398,11 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 
 // Process Status API (PSAPI)
 //sys	EnumProcesses(processIds []uint32, bytesReturned *uint32) (err error) = psapi.EnumProcesses
+//sys	EnumProcessModules(process Handle, module *Handle, cb uint32, cbNeeded *uint32) (err error) = psapi.EnumProcessModules
+//sys	EnumProcessModulesEx(process Handle, module *Handle, cb uint32, cbNeeded *uint32, filterFlag uint32) (err error) = psapi.EnumProcessModulesEx
+//sys	GetModuleInformation(process Handle, module Handle, modinfo *ModuleInfo, cb uint32) (err error) = psapi.GetModuleInformation
+//sys	GetModuleFileNameEx(process Handle, module Handle, filename *uint16, size uint32) (err error) = psapi.GetModuleFileNameExW
+//sys	GetModuleBaseName(process Handle, module Handle, baseName *uint16, size uint32) (err error) = psapi.GetModuleBaseNameW
 
 // NT Native APIs
 //sys	rtlNtStatusToDosErrorNoTeb(ntstatus NTStatus) (ret syscall.Errno) = ntdll.RtlNtStatusToDosErrorNoTeb

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -765,9 +765,11 @@ func TestProcessModules(t *testing.T) {
 	} else {
 		switch runtime.GOARCH {
 		case "amd64":
+			arch = 64
 		case "arm64":
 			arch = 64
 		case "386":
+			arch = 64
 		case "arm":
 			arch = 32
 		}

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -769,7 +769,7 @@ func TestProcessModules(t *testing.T) {
 		case "arm64":
 			arch = 64
 		case "386":
-			arch = 64
+			arch = 32
 		case "arm":
 			arch = 32
 		}

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -712,78 +712,68 @@ func TestProcessModules(t *testing.T) {
 	var cbNeeded uint32
 	err = windows.EnumProcessModules(process, &module, uint32(unsafe.Sizeof(module)), &cbNeeded)
 	if err != nil {
-		t.Errorf("unable to call EnumProcessModules: %v", err)
+		t.Fatalf("EnumProcessModules failed: %v", err)
 	}
 
 	var moduleEx windows.Handle
 	err = windows.EnumProcessModulesEx(process, &moduleEx, uint32(unsafe.Sizeof(moduleEx)), &cbNeeded, windows.LIST_MODULES_DEFAULT)
 	if err != nil {
-		t.Errorf("unable to call EnumProcessModulesEx: %v", err)
+		t.Fatalf("EnumProcessModulesEx failed: %v", err)
 	}
 	if module != moduleEx {
-		t.Errorf("module from EnumProcessModules does not match EnumProcessModulesEx: %v != %v", module, moduleEx)
+		t.Fatalf("module from EnumProcessModules does not match EnumProcessModulesEx: %v != %v", module, moduleEx)
 	}
 
 	exePath, err := os.Executable()
 	if err != nil {
-		t.Errorf("unable to get current executable path: %v", err)
+		t.Fatalf("unable to get current executable path: %v", err)
 	}
 
-	modulePathUTF := make([]uint16, len(exePath)+1)
-	err = windows.GetModuleFileNameEx(process, module, &modulePathUTF[0], uint32(len(modulePathUTF)))
+	modulePathUTF16 := make([]uint16, len(exePath)+1)
+	err = windows.GetModuleFileNameEx(process, module, &modulePathUTF16[0], uint32(len(modulePathUTF16)))
 	if err != nil {
-		t.Errorf("unable to call GetModuleFileNameEx: %v", err)
+		t.Fatalf("GetModuleFileNameEx failed: %v", err)
 	}
 
-	modulePath := windows.UTF16ToString(modulePathUTF)
+	modulePath := windows.UTF16ToString(modulePathUTF16)
 	if modulePath != exePath {
-		t.Errorf("module does not match executable for GetModuleFileNameEx: %s != %s", modulePath, exePath)
+		t.Fatalf("module does not match executable for GetModuleFileNameEx: %s != %s", modulePath, exePath)
 	}
 
-	err = windows.GetModuleBaseName(process, module, &modulePathUTF[0], uint32(len(modulePathUTF)))
+	err = windows.GetModuleBaseName(process, module, &modulePathUTF16[0], uint32(len(modulePathUTF16)))
 	if err != nil {
-		t.Errorf("unable to call GetModuleBaseName: %v", err)
+		t.Fatalf("GetModuleBaseName failed: %v", err)
 	}
 
-	modulePath = windows.UTF16ToString(modulePathUTF)
+	modulePath = windows.UTF16ToString(modulePathUTF16)
 	baseExePath := filepath.Base(exePath)
 	if modulePath != baseExePath {
-		t.Errorf("module does not match executable for GetModuleBaseName: %s != %s", modulePath, baseExePath)
+		t.Fatalf("module does not match executable for GetModuleBaseName: %s != %s", modulePath, baseExePath)
 	}
 
 	var moduleInfo windows.ModuleInfo
 	err = windows.GetModuleInformation(process, module, &moduleInfo, uint32(unsafe.Sizeof(moduleInfo)))
 	if err != nil {
-		t.Errorf("unable to call GetModuleInformation: %v", err)
+		t.Fatalf("GetModuleInformation failed: %v", err)
 	}
 
-	var arch int
-	var size uint32
 	peFile, err := pe.Open(exePath)
 	if err != nil {
-		t.Errorf("unable to open current executable: %v", err)
-	} else {
-		switch runtime.GOARCH {
-		case "amd64":
-			arch = 64
-		case "arm64":
-			arch = 64
-		case "386":
-			arch = 32
-		case "arm":
-			arch = 32
-		}
+		t.Fatalf("unable to open current executable: %v", err)
+	}
+	defer peFile.Close()
 
-		if arch == 32 {
-			size = peFile.OptionalHeader.(pe.OptionalHeader32).SizeOfImage
-		} else if arch == 64 {
-			size = peFile.OptionalHeader.(pe.OptionalHeader64).SizeOfImage
-		} else {
-			t.Logf("unable to test GetModuleInformation on arch %v", runtime.GOARCH)
-		}
+	var peSizeOfImage uint32
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+		peSizeOfImage = peFile.OptionalHeader.(*pe.OptionalHeader64).SizeOfImage
+	case "386", "arm":
+		peSizeOfImage = peFile.OptionalHeader.(*pe.OptionalHeader32).SizeOfImage
+	default:
+		t.Fatalf("unable to test GetModuleInformation on arch %v", runtime.GOARCH)
 	}
 
-	if arch != 0 && moduleInfo.SizeOfImage != size {
-		t.Errorf("module size does not match executable: %v != %v", moduleInfo.SizeOfImage, size)
+	if moduleInfo.SizeOfImage != peSizeOfImage {
+		t.Fatalf("module size does not match executable: %v != %v", moduleInfo.SizeOfImage, peSizeOfImage)
 	}
 }

--- a/windows/types_windows.go
+++ b/windows/types_windows.go
@@ -243,6 +243,14 @@ const (
 )
 
 const (
+	// flags for EnumProcessModulesEx
+	LIST_MODULES_32BIT   = 0x01
+	LIST_MODULES_64BIT   = 0x02
+	LIST_MODULES_ALL     = 0x03
+	LIST_MODULES_DEFAULT = 0x00
+)
+
+const (
 	// filters for ReadDirectoryChangesW and FindFirstChangeNotificationW
 	FILE_NOTIFY_CHANGE_FILE_NAME   = 0x001
 	FILE_NOTIFY_CHANGE_DIR_NAME    = 0x002
@@ -2773,3 +2781,9 @@ const (
 
 // Flag for QueryFullProcessImageName.
 const PROCESS_NAME_NATIVE = 1
+
+type ModuleInfo struct {
+	BaseOfDll   uintptr
+	SizeOfImage uint32
+	EntryPoint  uintptr
+}

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -377,7 +377,12 @@ var (
 	procCoTaskMemFree                                        = modole32.NewProc("CoTaskMemFree")
 	procCoUninitialize                                       = modole32.NewProc("CoUninitialize")
 	procStringFromGUID2                                      = modole32.NewProc("StringFromGUID2")
+	procEnumProcessModules                                   = modpsapi.NewProc("EnumProcessModules")
+	procEnumProcessModulesEx                                 = modpsapi.NewProc("EnumProcessModulesEx")
 	procEnumProcesses                                        = modpsapi.NewProc("EnumProcesses")
+	procGetModuleBaseNameW                                   = modpsapi.NewProc("GetModuleBaseNameW")
+	procGetModuleFileNameExW                                 = modpsapi.NewProc("GetModuleFileNameExW")
+	procGetModuleInformation                                 = modpsapi.NewProc("GetModuleInformation")
 	procSubscribeServiceChangeNotifications                  = modsechost.NewProc("SubscribeServiceChangeNotifications")
 	procUnsubscribeServiceChangeNotifications                = modsechost.NewProc("UnsubscribeServiceChangeNotifications")
 	procGetUserNameExW                                       = modsecur32.NewProc("GetUserNameExW")
@@ -3225,12 +3230,52 @@ func stringFromGUID2(rguid *GUID, lpsz *uint16, cchMax int32) (chars int32) {
 	return
 }
 
+func EnumProcessModules(process Handle, module *Handle, cb uint32, cbNeeded *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procEnumProcessModules.Addr(), 4, uintptr(process), uintptr(unsafe.Pointer(module)), uintptr(cb), uintptr(unsafe.Pointer(cbNeeded)), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func EnumProcessModulesEx(process Handle, module *Handle, cb uint32, cbNeeded *uint32, filterFlag uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procEnumProcessModulesEx.Addr(), 5, uintptr(process), uintptr(unsafe.Pointer(module)), uintptr(cb), uintptr(unsafe.Pointer(cbNeeded)), uintptr(filterFlag), 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
 func EnumProcesses(processIds []uint32, bytesReturned *uint32) (err error) {
 	var _p0 *uint32
 	if len(processIds) > 0 {
 		_p0 = &processIds[0]
 	}
 	r1, _, e1 := syscall.Syscall(procEnumProcesses.Addr(), 3, uintptr(unsafe.Pointer(_p0)), uintptr(len(processIds)), uintptr(unsafe.Pointer(bytesReturned)))
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func GetModuleBaseName(process Handle, module Handle, baseName *uint16, size uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procGetModuleBaseNameW.Addr(), 4, uintptr(process), uintptr(module), uintptr(unsafe.Pointer(baseName)), uintptr(size), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func GetModuleFileNameEx(process Handle, module Handle, filename *uint16, size uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procGetModuleFileNameExW.Addr(), 4, uintptr(process), uintptr(module), uintptr(unsafe.Pointer(filename)), uintptr(size), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func GetModuleInformation(process Handle, module Handle, modinfo *ModuleInfo, cb uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procGetModuleInformation.Addr(), 4, uintptr(process), uintptr(module), uintptr(unsafe.Pointer(modinfo)), uintptr(cb), 0, 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}


### PR DESCRIPTION
Add EnumProcessModules, EnumProcessModulesEx, GetModuleInformation, GetModuleFileNameEx and GetModuleBaseName.

https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-enumprocessmodules
https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-enumprocessmodulesex
https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmoduleinformation
https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmodulefilenameexw
https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmodulebasenamew