### PR TITLE
unix: SysvShmCtl should use ipc_64 on mips64(le)

### DIFF
--- a/unix/sysvshm_linux.go
+++ b/unix/sysvshm_linux.go
@@ -12,7 +12,7 @@ import "runtime"
 // SysvShmCtl performs control operations on the shared memory segment
 // specified by id.
 func SysvShmCtl(id, cmd int, desc *SysvShmDesc) (result int, err error) {
-	if runtime.GOARCH == "arm" {
+	if runtime.GOARCH == "arm" || runtime.GOARCH == "mips64" {
 		cmd |= ipc_64
 	}
 

--- a/unix/sysvshm_linux.go
+++ b/unix/sysvshm_linux.go
@@ -12,7 +12,8 @@ import "runtime"
 // SysvShmCtl performs control operations on the shared memory segment
 // specified by id.
 func SysvShmCtl(id, cmd int, desc *SysvShmDesc) (result int, err error) {
-	if runtime.GOARCH == "arm" || runtime.GOARCH == "mips64" {
+	if runtime.GOARCH == "arm" ||
+		runtime.GOARCH == "mips64" || runtime.GOARCH == "mips64le" {
 		cmd |= ipc_64
 	}
 


### PR DESCRIPTION
For golang/go#48708