### PR TITLE
unix: add SPEED_UNKNOWN

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -3755,6 +3755,8 @@ const (
 	ETHTOOL_A_TUNNEL_INFO_MAX                 = C.ETHTOOL_A_TUNNEL_INFO_MAX
 )
 
+const SPEED_UNKNOWN = C.SPEED_UNKNOWN
+
 type EthtoolDrvinfo C.struct_ethtool_drvinfo
 
 type (

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -3771,6 +3771,8 @@ const (
 	ETHTOOL_A_TUNNEL_INFO_MAX                 = 0x2
 )
 
+const SPEED_UNKNOWN = -0x1
+
 type EthtoolDrvinfo struct {
 	Cmd          uint32
 	Driver       [32]byte


### PR DESCRIPTION
The rest of the SPEED_* constants are redundant: SPEED_x is defined to simply x for x in 10, 100, ...