### PR TITLE
Removed usage of deprecated ioutil.ReadFile

### DIFF
--- a/cpu/hwcap_linux.go
+++ b/cpu/hwcap_linux.go
@@ -5,7 +5,7 @@
 package cpu
 
 import (
-	"io/ioutil"
+	"os"
 )
 
 const (
@@ -24,7 +24,7 @@ var hwCap uint
 var hwCap2 uint
 
 func readHWCAP() error {
-	buf, err := ioutil.ReadFile(procAuxv)
+	buf, err := os.ReadFile(procAuxv)
 	if err != nil {
 		// e.g. on android /proc/self/auxv is not accessible, so silently
 		// ignore the error and leave Initialized = false. On some


### PR DESCRIPTION
ioutil is deprecated. Using corresponding function in **os** package.