### PR TITLE
windows: replace uses of Close() with CloseHandle()

### DIFF
--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -755,7 +755,7 @@ func Utimes(path string, tv []Timeval) (err error) {
 	if e != nil {
 		return e
 	}
-	defer Close(h)
+	defer CloseHandle(h)
 	a := NsecToFiletime(tv[0].Nanoseconds())
 	w := NsecToFiletime(tv[1].Nanoseconds())
 	return SetFileTime(h, nil, &a, &w)
@@ -775,7 +775,7 @@ func UtimesNano(path string, ts []Timespec) (err error) {
 	if e != nil {
 		return e
 	}
-	defer Close(h)
+	defer CloseHandle(h)
 	a := NsecToFiletime(TimespecToNsec(ts[0]))
 	w := NsecToFiletime(TimespecToNsec(ts[1]))
 	return SetFileTime(h, nil, &a, &w)


### PR DESCRIPTION
Since https://golang.org/cl/4600042, Close is a straight wrapper of CloseHandle.
