### PR TITLE
windows/mkwinsyscall: remove errnoERROR_IO_PENDING const

### DIFF
--- a/windows/mkwinsyscall/mkwinsyscall.go
+++ b/windows/mkwinsyscall/mkwinsyscall.go
@@ -904,12 +904,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = {{syscalldot}}Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = {{windowsdot}}ERROR_IO_PENDING
 	errERROR_EINVAL error     = {{syscalldot}}EINVAL
 )
 
@@ -919,7 +915,7 @@ func errnoErr(e {{syscalldot}}Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case {{windowsdot}}ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/windows/registry/zsyscall_windows.go
+++ b/windows/registry/zsyscall_windows.go
@@ -13,12 +13,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = windows.ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -28,7 +24,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case windows.ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -11,12 +11,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -26,7 +22,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common


### PR DESCRIPTION
From the looks of it, this const is redundant (but perhaps there's something I'm overlooking 😅)