### PR TITLE
execabs: isGo119ErrDot: use errors.Is instead of string-matching

### DIFF
--- a/execabs/execabs_go119.go
+++ b/execabs/execabs_go119.go
@@ -7,9 +7,11 @@
 
 package execabs
 
-import "strings"
+import (
+	"errors"
+	"os/exec"
+)
 
 func isGo119ErrDot(err error) bool {
-	// TODO: return errors.Is(err, exec.ErrDot)
-	return strings.Contains(err.Error(), "current directory")
+	return errors.Is(err, exec.ErrDot)
 }


### PR DESCRIPTION
Addresses the TODO added in CL 403256.