### PR TITLE
unix: support TIOCGETA on GNU/Hurd

### DIFF
--- a/unix/gccgo.go
+++ b/unix/gccgo.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build gccgo && !aix
-// +build gccgo,!aix
+//go:build gccgo && !aix && !hurd
+// +build gccgo,!aix,!hurd
 
 package unix
 

--- a/unix/gccgo_c.c
+++ b/unix/gccgo_c.c
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build gccgo
-// +build !aix
+// +build gccgo,!hurd
+// +build !aix,!hurd
 
 #include <errno.h>
 #include <stdint.h>

--- a/unix/ioctl.go
+++ b/unix/ioctl.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+//go:build aix || darwin || dragonfly || freebsd || hurd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd hurd linux netbsd openbsd solaris
 
 package unix
 

--- a/unix/syscall_hurd.go
+++ b/unix/syscall_hurd.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build hurd
+// +build hurd
+
+package unix
+
+/*
+#include <stdint.h>
+int ioctl(int, unsigned long int, uintptr_t);
+*/
+import "C"
+
+func ioctl(fd int, req uint, arg uintptr) (err error) {
+	r0, er := C.ioctl(C.int(fd), C.ulong(req), C.uintptr_t(arg))
+	if r0 == -1 && er != nil {
+		err = er
+	}
+	return
+}
+

--- a/unix/syscall_hurd_386.go
+++ b/unix/syscall_hurd_386.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build 386 && hurd
+// +build 386,hurd
+
+package unix
+
+const (
+	TIOCGETA                       = 0x62251713
+)
+
+type Winsize struct {
+	Row    uint16
+	Col    uint16
+	Xpixel uint16
+	Ypixel uint16
+}
+
+type Termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]uint8
+	Ispeed int32
+	Ospeed int32
+}


### PR DESCRIPTION
Add minimal support for GNU/Hurd to allow building third party packages
which detect terminal support.