### PR TITLE
Add Registry Standard Access Rights

### DIFF
--- a/windows/registry/key.go
+++ b/windows/registry/key.go
@@ -33,6 +33,14 @@ const (
 	// Registry key security and access rights.
 	// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms724878.aspx
 	// for details.
+
+	// Standard access rights
+	DELETE       = 0x00010000
+	READ_CONTROL = 0x00020000
+	WRITE_DAC    = 0x00040000
+	WRITE_OWNER  = 0x00080000
+
+	// Specific access rights
 	ALL_ACCESS         = 0xf003f
 	CREATE_LINK        = 0x00020
 	CREATE_SUB_KEY     = 0x00004


### PR DESCRIPTION
The description of registry access rights in MSDN is divided into two categories: standard access rights and specific access rights.

https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-key-security-and-access-rights
![image](https://user-images.githubusercontent.com/117639542/211464525-1c76a795-f252-4002-b2b1-e9d0fb6755fb.png)

If standard access permissions are not supported, access will be denied due to excessive application permissions during use.

for example:

The access permissions of keys in HKLM are very limited, they are all readable, but other permissions are not sure.

For the permissions of the administrators group, there are special permissions in addition to read-only.
![image](https://user-images.githubusercontent.com/117639542/211465187-9bb2b7eb-28ec-4df0-9e47-5c13e84cafc7.png)

The following are the permissions of special permissions.
![image](https://user-images.githubusercontent.com/117639542/211465140-8c670a9e-ecec-4a0b-b11f-660cbfe0c631.png)

When I want to delete the key in HKLM, I can only choose KEY_SET_VALUE (Required to create, delete, or set a registry value.) in the code at present, but there is no create and set permission at present, and it will return Access is denied.

But if you only use the delete permission, there will be no problem.

![image](https://user-images.githubusercontent.com/117639542/211466681-3d085beb-cc8a-4771-82c5-6469ef0d3bd8.png)

![image](https://user-images.githubusercontent.com/117639542/211466841-cd26191b-6353-486d-a726-020458cec90a.png)

