### PR TITLE
unix: replace use of strcpy in mkerrors.sh

### DIFF
--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -741,7 +741,8 @@ main(void)
 		e = errors[i].num;
 		if(i > 0 && errors[i-1].num == e)
 			continue;
-		strcpy(buf, strerror(e));
+		strncpy(buf, strerror(e), sizeof(buf) - 1);
+		buf[sizeof(buf) - 1] = '\0';
 		// lowercase first letter: Bad -> bad, but STREAM -> STREAM.
 		if(A <= buf[0] && buf[0] <= Z && a <= buf[1] && buf[1] <= z)
 			buf[0] += a - A;
@@ -760,7 +761,8 @@ main(void)
 		e = signals[i].num;
 		if(i > 0 && signals[i-1].num == e)
 			continue;
-		strcpy(buf, strsignal(e));
+		strncpy(buf, strsignal(e), sizeof(buf) - 1);
+		buf[sizeof(buf) - 1] = '\0';
 		// lowercase first letter: Bad -> bad, but STREAM -> STREAM.
 		if(A <= buf[0] && buf[0] <= Z && a <= buf[1] && buf[1] <= z)
 			buf[0] += a - A;


### PR DESCRIPTION
On OpenBSD-current, clang emits a warning message to standard output for the use of strcpy, e.g.:

_errors.c(/tmp/_errors-673190.o:(main)): warning: strcpy() is almost always misused, please use strlcpy()

This message makes it into the Go source being created, causing gofmt to error on the invalid syntax, and leaving the zerrors file empty.

Using strlcpy would be preferred here, but strncpy is enough to silence this message, and is more portable.