### PR TITLE
windows: fix constant values for JobObjectInformationClass

### DIFF
--- a/windows/types_windows.go
+++ b/windows/types_windows.go
@@ -2229,10 +2229,10 @@ const (
 	JobObjectExtendedLimitInformation           = 9
 	JobObjectGroupInformation                   = 11
 	JobObjectGroupInformationEx                 = 14
-	JobObjectLimitViolationInformation2         = 35
+	JobObjectLimitViolationInformation2         = 34
 	JobObjectNetRateControlInformation          = 32
 	JobObjectNotificationLimitInformation       = 12
-	JobObjectNotificationLimitInformation2      = 34
+	JobObjectNotificationLimitInformation2      = 33
 	JobObjectSecurityLimitInformation           = 5
 )
 


### PR DESCRIPTION
The constant values were incorrect and has been fixed in this CL.

Reference:
https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-setinformationjobobject#parameters