### PR TITLE
unix: fix mkerrors.sh on NetBSD

### DIFF
--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -337,6 +337,8 @@ struct ltchars {
 includes_NetBSD='
 #include <sys/types.h>
 #include <sys/param.h>
+#include <sys/disk.h>
+#include <sys/disklabel.h>
 #include <sys/event.h>
 #include <sys/extattr.h>
 #include <sys/mman.h>


### PR DESCRIPTION
Running `mkall.sh` on NetBSD/amd64 9.3 fails:

```
$ GOOS=netbsd GOARCH=amd64 ./mkall.sh
/home/tim/sys/unix/_const.go:249:15: could not determine kind of name for C.DIOCAWEDGE
/home/tim/sys/unix/_const.go:251:15: could not determine kind of name for C.DIOCBSLIST
/home/tim/sys/unix/_const.go:254:15: could not determine kind of name for C.DIOCDWEDGE
/home/tim/sys/unix/_const.go:257:18: could not determine kind of name for C.DIOCGDEFLABEL
/home/tim/sys/unix/_const.go:258:15: could not determine kind of name for C.DIOCGDINFO
/home/tim/sys/unix/_const.go:261:21: could not determine kind of name for C.DIOCGSECTORALIGN
/home/tim/sys/unix/_const.go:263:18: could not determine kind of name for C.DIOCGSTRATEGY
/home/tim/sys/unix/_const.go:264:19: could not determine kind of name for C.DIOCGWEDGEINFO
/home/tim/sys/unix/_const.go:267:16: could not determine kind of name for C.DIOCLWEDGES
/home/tim/sys/unix/_const.go:269:16: could not determine kind of name for C.DIOCRFORMAT
/home/tim/sys/unix/_const.go:271:13: could not determine kind of name for C.DIOCSBAD
/home/tim/sys/unix/_const.go:273:15: could not determine kind of name for C.DIOCSDINFO
/home/tim/sys/unix/_const.go:276:18: could not determine kind of name for C.DIOCSSTRATEGY
/home/tim/sys/unix/_const.go:278:15: could not determine kind of name for C.DIOCWDINFO
/home/tim/sys/unix/_const.go:279:16: could not determine kind of name for C.DIOCWFORMAT
```

(I tried with Go 1.18.3 from NetBSD's package manager and with Go 1.20.2 built from source.)

The reported names are ioctls defined in `<sys/dkio.h>`. These ioctls refer to types defined in headers that apparently are not included. This PR adds these headers to `mkerr.sh`, but it does not include the changes in the regenerated files.