### PR TITLE
unix: expose UTIME_NOW and UTIME_OMIT on Darwin and NetBSD

### DIFF
--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -68,6 +68,7 @@ includes_Darwin='
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/sockio.h>
+#include <sys/stat.h>
 #include <sys/sys_domain.h>
 #include <sys/sysctl.h>
 #include <sys/mman.h>
@@ -345,6 +346,7 @@ includes_NetBSD='
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/sockio.h>
+#include <sys/stat.h>
 #include <sys/sysctl.h>
 #include <sys/termios.h>
 #include <sys/ttycom.h>


### PR DESCRIPTION
This PR does not include the changes in the regenerated files. Also, perhaps this PR should be rebased on #151.