### PR TITLE
windows/svc/mgr: Service.Control: populate Status when returning certain errors

### DIFF
--- a/windows/svc/mgr/mgr_test.go
+++ b/windows/svc/mgr/mgr_test.go
@@ -262,9 +262,7 @@ func TestMyService(t *testing.T) {
 		t.Fatalf("service %s is not installed", name)
 	}
 	defer s.Close()
-	defer func() {
-		_ = s.Delete()
-	}()
+	defer s.Delete()
 
 	c.BinaryPathName = exepath
 	c = testConfig(t, s, c)

--- a/windows/svc/mgr/mgr_test.go
+++ b/windows/svc/mgr/mgr_test.go
@@ -209,6 +209,16 @@ func testRecoveryCommand(t *testing.T, s *mgr.Service, should string) {
 	}
 }
 
+func testControl(t *testing.T, s *mgr.Service, c svc.Cmd, expectedErr error, expectedStatus svc.Status) {
+	status, err := s.Control(c)
+	if err != expectedErr {
+		t.Fatalf("Unexpected return from s.Control: %v (expected %v)", err, expectedErr)
+	}
+	if expectedStatus != status {
+		t.Fatalf("Unexpected status from s.Control: %+v (expected %+v)", status, expectedStatus)
+	}
+}
+
 func remove(t *testing.T, s *mgr.Service) {
 	err := s.Delete()
 	if err != nil {
@@ -300,13 +310,7 @@ func TestMyService(t *testing.T) {
 	expectedStatus := svc.Status{
 		State: svc.Stopped,
 	}
-	status, err := s.Control(svc.Stop)
-	if err != windows.ERROR_SERVICE_NOT_ACTIVE {
-		t.Fatalf("Unexpected return from s.Control: %v (expected %v)", err, windows.ERROR_SERVICE_NOT_ACTIVE)
-	}
-	if expectedStatus != status {
-		t.Fatalf("Unexpected status from s.Control: %+v (expected %+v)", status, expectedStatus)
-	}
+	testControl(t, s, svc.Stop, windows.ERROR_SERVICE_NOT_ACTIVE, expectedStatus)
 
 	remove(t, s)
 }

--- a/windows/svc/mgr/service.go
+++ b/windows/svc/mgr/service.go
@@ -45,7 +45,12 @@ func (s *Service) Start(args ...string) error {
 	return windows.StartService(s.Handle, uint32(len(args)), p)
 }
 
-// Control sends state change request c to the service s.
+// Control sends state change request c to the service s. It returns the most
+// recent status the service reported to the service control manager, and an
+// error if the state change request was not accepted.
+// Note that the service status is only returned if the status change request
+// succeeded, or if it failed with error ERROR_INVALID_SERVICE_CONTROL,
+// ERROR_SERVICE_CANNOT_ACCEPT_CTRL, or ERROR_SERVICE_NOT_ACTIVE.
 func (s *Service) Control(c svc.Cmd) (svc.Status, error) {
 	var t windows.SERVICE_STATUS
 	err := windows.ControlService(s.Handle, uint32(c), &t)

--- a/windows/svc/mgr/service.go
+++ b/windows/svc/mgr/service.go
@@ -49,13 +49,16 @@ func (s *Service) Start(args ...string) error {
 func (s *Service) Control(c svc.Cmd) (svc.Status, error) {
 	var t windows.SERVICE_STATUS
 	err := windows.ControlService(s.Handle, uint32(c), &t)
-	if err != nil {
+	if err != nil &&
+		err != windows.ERROR_INVALID_SERVICE_CONTROL &&
+		err != windows.ERROR_SERVICE_CANNOT_ACCEPT_CTRL &&
+		err != windows.ERROR_SERVICE_NOT_ACTIVE {
 		return svc.Status{}, err
 	}
 	return svc.Status{
 		State:   svc.State(t.CurrentState),
 		Accepts: svc.Accepted(t.ControlsAccepted),
-	}, nil
+	}, err
 }
 
 // Query returns current status of service s.

--- a/windows/svc/mgr/service.go
+++ b/windows/svc/mgr/service.go
@@ -48,8 +48,8 @@ func (s *Service) Start(args ...string) error {
 // Control sends state change request c to the service s. It returns the most
 // recent status the service reported to the service control manager, and an
 // error if the state change request was not accepted.
-// Note that the service status is only populated if the status change request
-// succeeded, or if it failed with error ERROR_INVALID_SERVICE_CONTROL,
+// Note that the returned service status is only set if the status change
+// request succeeded, or if it failed with error ERROR_INVALID_SERVICE_CONTROL,
 // ERROR_SERVICE_CANNOT_ACCEPT_CTRL, or ERROR_SERVICE_NOT_ACTIVE.
 func (s *Service) Control(c svc.Cmd) (svc.Status, error) {
 	var t windows.SERVICE_STATUS

--- a/windows/svc/mgr/service.go
+++ b/windows/svc/mgr/service.go
@@ -48,7 +48,7 @@ func (s *Service) Start(args ...string) error {
 // Control sends state change request c to the service s. It returns the most
 // recent status the service reported to the service control manager, and an
 // error if the state change request was not accepted.
-// Note that the service status is only returned if the status change request
+// Note that the service status is only populated if the status change request
 // succeeded, or if it failed with error ERROR_INVALID_SERVICE_CONTROL,
 // ERROR_SERVICE_CANNOT_ACCEPT_CTRL, or ERROR_SERVICE_NOT_ACTIVE.
 func (s *Service) Control(c svc.Cmd) (svc.Status, error) {


### PR DESCRIPTION
Fixes golang/go#59015