### PR TITLE
unix: remove absolute path of pwd from mkall.sh

### DIFF
--- a/unix/mkall.sh
+++ b/unix/mkall.sh
@@ -50,7 +50,7 @@ if [[ "$GOOS" = "linux" ]]; then
 	# Use the Docker-based build system
 	# Files generated through docker (use $cmd so you can Ctl-C the build or run)
 	$cmd docker build --tag generate:$GOOS $GOOS
-	$cmd docker run --interactive --tty --volume $(cd -- "$(dirname -- "$0")/.." && /bin/pwd):/build generate:$GOOS
+	$cmd docker run --interactive --tty --volume $(cd -- "$(dirname -- "$0")/.." && pwd):/build generate:$GOOS
 	exit
 fi
 


### PR DESCRIPTION
The pwd command does not always reside under /bin for all Linux
distributions. As a $PATH is otherwise always assumed, here too.