### PR TITLE
unix: fix mkerrors.sh on OpenBSD by using strlcpy

### DIFF
--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -741,7 +741,11 @@ main(void)
 		e = errors[i].num;
 		if(i > 0 && errors[i-1].num == e)
 			continue;
+#ifdef __OpenBSD__
+		strlcpy(buf, strerror(e), sizeof(buf));
+#else
 		strcpy(buf, strerror(e));
+#endif /* __OpenBSD __*/
 		// lowercase first letter: Bad -> bad, but STREAM -> STREAM.
 		if(A <= buf[0] && buf[0] <= Z && a <= buf[1] && buf[1] <= z)
 			buf[0] += a - A;
@@ -760,7 +764,11 @@ main(void)
 		e = signals[i].num;
 		if(i > 0 && signals[i-1].num == e)
 			continue;
+#ifdef __OpenBSD__
+		strlcpy(buf, strsignal(e), sizeof(buf));
+#else
 		strcpy(buf, strsignal(e));
+#endif /* __OpenBSD __*/
 		// lowercase first letter: Bad -> bad, but STREAM -> STREAM.
 		if(A <= buf[0] && buf[0] <= Z && a <= buf[1] && buf[1] <= z)
 			buf[0] += a - A;


### PR DESCRIPTION
On OpenBSD, strcpy causes an error message output that recommends the use of strlcpy[0]. Here, the result was that this output became part of the generated program code, causing gofmt to fail and create an empty zerrors_openbsd_GOARCH.go file.

An ifdef guard has been added within the C code which uses the desired strlcpy function under OpenBSD. Other operating systems continue to use strcpy.

[0] https://github.com/openbsd/src/blob/958bc3ae91838214c6d3bb7efc272663a5df7b01/lib/libc/string/strcpy.c#L34-L37