### PR TITLE
cpu: add support for amx detection

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -54,6 +54,10 @@ var X86 struct {
 	HasAVX512VBMI2      bool // Advanced vector extension 512 Vector Byte Manipulation Instructions 2
 	HasAVX512BITALG     bool // Advanced vector extension 512 Bit Algorithms
 	HasAVX512BF16       bool // Advanced vector extension 512 BFloat16 Instructions
+	HasAMX              bool // Advanced Matrix Extension
+	HasAMXTile          bool // Advanced Matrix Extension Tile instructions
+	HasAMXInt8          bool // Advanced Matrix Extension Int8 instructions
+	HasAMXBF16          bool // Advanced Matrix Extension BFloat16 instructions
 	HasBMI1             bool // Bit manipulation instruction set 1
 	HasBMI2             bool // Bit manipulation instruction set 2
 	HasCX16             bool // Compare and exchange 16 Bytes

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -54,7 +54,6 @@ var X86 struct {
 	HasAVX512VBMI2      bool // Advanced vector extension 512 Vector Byte Manipulation Instructions 2
 	HasAVX512BITALG     bool // Advanced vector extension 512 Bit Algorithms
 	HasAVX512BF16       bool // Advanced vector extension 512 BFloat16 Instructions
-	HasAMX              bool // Advanced Matrix Extension
 	HasAMXTile          bool // Advanced Matrix Extension Tile instructions
 	HasAMXInt8          bool // Advanced Matrix Extension Int8 instructions
 	HasAMXBF16          bool // Advanced Matrix Extension BFloat16 instructions

--- a/cpu/cpu_x86.go
+++ b/cpu/cpu_x86.go
@@ -143,12 +143,9 @@ func archInit() {
 		X86.HasAVX512BF16 = isSet(5, eax71)
 	}
 
-	X86.HasAMX = isSet(24, edx7)
-	if X86.HasAMX {
-		X86.HasAMXTile = true
-		X86.HasAMXInt8 = isSet(25, edx7)
-		X86.HasAMXBF16 = isSet(22, edx7)
-	}
+	X86.HasAMXTile = isSet(24, edx7)
+	X86.HasAMXInt8 = isSet(25, edx7)
+	X86.HasAMXBF16 = isSet(22, edx7)
 }
 
 func isSet(bitpos uint, value uint32) bool {

--- a/cpu/cpu_x86.go
+++ b/cpu/cpu_x86.go
@@ -37,7 +37,6 @@ func initOptions() {
 		{Name: "avx512vbmi2", Feature: &X86.HasAVX512VBMI2},
 		{Name: "avx512bitalg", Feature: &X86.HasAVX512BITALG},
 		{Name: "avx512bf16", Feature: &X86.HasAVX512BF16},
-		{Name: "amx", Feature: &X86.HasAMX},
 		{Name: "amxtile", Feature: &X86.HasAMXTile},
 		{Name: "amxint8", Feature: &X86.HasAMXInt8},
 		{Name: "amxbf16", Feature: &X86.HasAMXBF16},

--- a/cpu/cpu_x86.go
+++ b/cpu/cpu_x86.go
@@ -37,6 +37,10 @@ func initOptions() {
 		{Name: "avx512vbmi2", Feature: &X86.HasAVX512VBMI2},
 		{Name: "avx512bitalg", Feature: &X86.HasAVX512BITALG},
 		{Name: "avx512bf16", Feature: &X86.HasAVX512BF16},
+		{Name: "amx", Feature: &X86.HasAMX},
+		{Name: "amxtile", Feature: &X86.HasAMXTile},
+		{Name: "amxint8", Feature: &X86.HasAMXInt8},
+		{Name: "amxbf16", Feature: &X86.HasAMXBF16},
 		{Name: "bmi1", Feature: &X86.HasBMI1},
 		{Name: "bmi2", Feature: &X86.HasBMI2},
 		{Name: "cx16", Feature: &X86.HasCX16},
@@ -137,6 +141,13 @@ func archInit() {
 
 		eax71, _, _, _ := cpuid(7, 1)
 		X86.HasAVX512BF16 = isSet(5, eax71)
+	}
+
+	X86.HasAMX = isSet(24, edx7)
+	if X86.HasAMX {
+		X86.HasAMXTile = true
+		X86.HasAMXInt8 = isSet(25, edx7)
+		X86.HasAMXBF16 = isSet(22, edx7)
 	}
 }
 


### PR DESCRIPTION
Added detection for x86 AMX,
including AMX-Tile, AMX-INT8 and AMX-BF16
instruction sets.