### PR TITLE
unix: require minimum OpenBSD 6.4 for pledge, unveil

### DIFF
--- a/unix/pledge_openbsd.go
+++ b/unix/pledge_openbsd.go
@@ -20,8 +20,7 @@ import (
 //
 // For more information see pledge(2).
 func Pledge(promises, execpromises string) error {
-	err := pledgeAvailable()
-	if err != nil {
+	if err := pledgeAvailable(); err != nil {
 		return err
 	}
 
@@ -50,8 +49,7 @@ func Pledge(promises, execpromises string) error {
 //
 // For more information see pledge(2).
 func PledgePromises(promises string) error {
-	err := pledgeAvailable()
-	if err != nil {
+	if err := pledgeAvailable(); err != nil {
 		return err
 	}
 
@@ -78,8 +76,7 @@ func PledgePromises(promises string) error {
 //
 // For more information see pledge(2).
 func PledgeExecpromises(execpromises string) error {
-	err := pledgeAvailable()
-	if err != nil {
+	if err := pledgeAvailable(); err != nil {
 		return err
 	}
 
@@ -133,8 +130,7 @@ func pledgeAvailable() error {
 
 	// Require OpenBSD 6.4 as a minimum.
 	if maj < 6 || (maj == 6 && min <= 3) {
-		return fmt.Errorf("cannot call Pledge on OpenBSD %d.%d", maj,
-			min)
+		return fmt.Errorf("cannot call Pledge on OpenBSD %d.%d", maj, min)
 	}
 
 	return nil

--- a/unix/pledge_openbsd.go
+++ b/unix/pledge_openbsd.go
@@ -35,7 +35,8 @@ func Pledge(promises, execpromises string) error {
 		return err
 	}
 
-	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(unsafe.Pointer(pptr)), uintptr(unsafe.Pointer(exptr)), 0)
+	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(unsafe.Pointer(pptr)),
+		uintptr(unsafe.Pointer(exptr)), 0)
 	if e != 0 {
 		return e
 	}
@@ -62,7 +63,8 @@ func PledgePromises(promises string) error {
 		return err
 	}
 
-	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(unsafe.Pointer(pptr)), uintptr(expr), 0)
+	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(unsafe.Pointer(pptr)),
+		uintptr(expr), 0)
 	if e != 0 {
 		return e
 	}
@@ -89,7 +91,8 @@ func PledgeExecpromises(execpromises string) error {
 		return err
 	}
 
-	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(pptr), uintptr(unsafe.Pointer(exptr)), 0)
+	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(pptr),
+		uintptr(unsafe.Pointer(exptr)), 0)
 	if e != 0 {
 		return e
 	}
@@ -130,7 +133,8 @@ func pledgeAvailable() error {
 
 	// Require OpenBSD 6.4 as a minimum.
 	if maj < 6 || (maj == 6 && min <= 3) {
-		return fmt.Errorf("cannot call Pledge on OpenBSD %d.%d", maj, min)
+		return fmt.Errorf("cannot call Pledge on OpenBSD %d.%d", maj,
+			min)
 	}
 
 	return nil

--- a/unix/pledge_openbsd.go
+++ b/unix/pledge_openbsd.go
@@ -34,9 +34,8 @@ func Pledge(promises, execpromises string) error {
 	if err != nil {
 		return err
 	}
-	expr := unsafe.Pointer(exptr)
 
-	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(unsafe.Pointer(pptr)), uintptr(expr), 0)
+	_, _, e := syscall.Syscall(SYS_PLEDGE, uintptr(unsafe.Pointer(pptr)), uintptr(unsafe.Pointer(exptr)), 0)
 	if e != 0 {
 		return e
 	}

--- a/unix/unveil_openbsd.go
+++ b/unix/unveil_openbsd.go
@@ -15,8 +15,7 @@ import (
 // Note that the special case of blocking further
 // unveil calls is handled by UnveilBlock.
 func Unveil(path string, flags string) error {
-	err := supportsUnveil()
-	if err != nil {
+	if err := supportsUnveil(); err != nil {
 		return err
 	}
 	pathPtr, err := syscall.BytePtrFromString(path)
@@ -37,8 +36,7 @@ func Unveil(path string, flags string) error {
 // UnveilBlock blocks future unveil calls.
 // For more information see unveil(2).
 func UnveilBlock() error {
-	err := supportsUnveil()
-	if err != nil {
+	if err := supportsUnveil(); err != nil {
 		return err
 	}
 	// Both pointers must be nil.
@@ -60,8 +58,7 @@ func supportsUnveil() error {
 
 	// unveil is not available before 6.4
 	if maj < 6 || (maj == 6 && min <= 3) {
-		return fmt.Errorf("cannot call Unveil on OpenBSD %d.%d", maj,
-			min)
+		return fmt.Errorf("cannot call Unveil on OpenBSD %d.%d", maj, min)
 	}
 
 	return nil

--- a/unix/unveil_openbsd.go
+++ b/unix/unveil_openbsd.go
@@ -60,7 +60,8 @@ func supportsUnveil() error {
 
 	// unveil is not available before 6.4
 	if maj < 6 || (maj == 6 && min <= 3) {
-		return fmt.Errorf("cannot call Unveil on OpenBSD %d.%d", maj, min)
+		return fmt.Errorf("cannot call Unveil on OpenBSD %d.%d", maj,
+			min)
 	}
 
 	return nil


### PR DESCRIPTION
OpenBSD 7.3 and 7.4 are the only supported OpenBSD releases.  This change simplifies the version detection and error handling to require at least OpenBSD 6.4 to call the Pledge and Unveil functions.

Updates golang/go#63569.