### PR TITLE
x/sys/unix/linux: update Linux kernel to v6.6

### DIFF
--- a/unix/linux/Dockerfile
+++ b/unix/linux/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y  --no-install-recommends \
 # Get the git sources. If not cached, this takes O(5 minutes).
 WORKDIR /git
 RUN git config --global advice.detachedHead false
-# Linux Kernel: Released 27 August 2023
-RUN git clone --branch v6.5 --depth 1 https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux
+# Linux Kernel: Released 30 October 2023
+RUN git clone --branch v6.6 --depth 1 https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux
 # GNU C library: Released 1 Feb 2023
 RUN git clone --branch release/2.37/master --depth 1 https://sourceware.org/git/glibc.git
 

--- a/unix/zerrors_linux.go
+++ b/unix/zerrors_linux.go
@@ -480,10 +480,14 @@ const (
 	BPF_FROM_BE                                 = 0x8
 	BPF_FROM_LE                                 = 0x0
 	BPF_FS_MAGIC                                = 0xcafe4a11
+	BPF_F_AFTER                                 = 0x10
 	BPF_F_ALLOW_MULTI                           = 0x2
 	BPF_F_ALLOW_OVERRIDE                        = 0x1
 	BPF_F_ANY_ALIGNMENT                         = 0x2
-	BPF_F_KPROBE_MULTI_RETURN                   = 0x1
+	BPF_F_BEFORE                                = 0x8
+	BPF_F_ID                                    = 0x20
+	BPF_F_LINK                                  = 0x2000
+	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
 	BPF_F_QUERY_EFFECTIVE                       = 0x1
 	BPF_F_REPLACE                               = 0x4
 	BPF_F_SLEEPABLE                             = 0x10
@@ -520,6 +524,7 @@ const (
 	BPF_MAJOR_VERSION                           = 0x1
 	BPF_MAXINSNS                                = 0x1000
 	BPF_MEM                                     = 0x60
+	BPF_MEMSX                                   = 0x80
 	BPF_MEMWORDS                                = 0x10
 	BPF_MINOR_VERSION                           = 0x1
 	BPF_MISC                                    = 0x7
@@ -775,6 +780,8 @@ const (
 	DEVLINK_GENL_MCGRP_CONFIG_NAME              = "config"
 	DEVLINK_GENL_NAME                           = "devlink"
 	DEVLINK_GENL_VERSION                        = 0x1
+	DEVLINK_PORT_FN_CAP_IPSEC_CRYPTO            = 0x4
+	DEVLINK_PORT_FN_CAP_IPSEC_PACKET            = 0x8
 	DEVLINK_PORT_FN_CAP_MIGRATABLE              = 0x2
 	DEVLINK_PORT_FN_CAP_ROCE                    = 0x1
 	DEVLINK_SB_THRESHOLD_TO_ALPHA_MAX           = 0x14
@@ -1697,6 +1704,7 @@ const (
 	KEXEC_ON_CRASH                              = 0x1
 	KEXEC_PRESERVE_CONTEXT                      = 0x2
 	KEXEC_SEGMENT_MAX                           = 0x10
+	KEXEC_UPDATE_ELFCOREHDR                     = 0x4
 	KEYCTL_ASSUME_AUTHORITY                     = 0x10
 	KEYCTL_CAPABILITIES                         = 0x1f
 	KEYCTL_CAPS0_BIG_KEY                        = 0x10
@@ -2274,6 +2282,7 @@ const (
 	PERF_MEM_LVLNUM_PMEM                        = 0xe
 	PERF_MEM_LVLNUM_RAM                         = 0xd
 	PERF_MEM_LVLNUM_SHIFT                       = 0x21
+	PERF_MEM_LVLNUM_UNC                         = 0x8
 	PERF_MEM_LVL_HIT                            = 0x2
 	PERF_MEM_LVL_IO                             = 0x1000
 	PERF_MEM_LVL_L1                             = 0x8
@@ -3460,6 +3469,7 @@ const (
 	XDP_PACKET_HEADROOM                         = 0x100
 	XDP_PGOFF_RX_RING                           = 0x0
 	XDP_PGOFF_TX_RING                           = 0x80000000
+	XDP_PKT_CONTD                               = 0x1
 	XDP_RING_NEED_WAKEUP                        = 0x1
 	XDP_RX_RING                                 = 0x2
 	XDP_SHARED_UMEM                             = 0x1
@@ -3472,6 +3482,7 @@ const (
 	XDP_UMEM_REG                                = 0x4
 	XDP_UMEM_UNALIGNED_CHUNK_FLAG               = 0x1
 	XDP_USE_NEED_WAKEUP                         = 0x8
+	XDP_USE_SG                                  = 0x10
 	XDP_ZEROCOPY                                = 0x4
 	XENFS_SUPER_MAGIC                           = 0xabba1974
 	XFS_SUPER_MAGIC                             = 0x58465342

--- a/unix/zerrors_linux_loong64.go
+++ b/unix/zerrors_linux_loong64.go
@@ -118,6 +118,7 @@ const (
 	IXOFF                            = 0x1000
 	IXON                             = 0x400
 	LASX_CTX_MAGIC                   = 0x41535801
+	LBT_CTX_MAGIC                    = 0x42540001
 	LSX_CTX_MAGIC                    = 0x53580001
 	MAP_ANON                         = 0x20
 	MAP_ANONYMOUS                    = 0x20

--- a/unix/zerrors_linux_riscv64.go
+++ b/unix/zerrors_linux_riscv64.go
@@ -227,6 +227,9 @@ const (
 	PPPIOCUNBRIDGECHAN               = 0x7434
 	PPPIOCXFERUNIT                   = 0x744e
 	PR_SET_PTRACER_ANY               = 0xffffffffffffffff
+	PTRACE_GETFDPIC                  = 0x21
+	PTRACE_GETFDPIC_EXEC             = 0x0
+	PTRACE_GETFDPIC_INTERP           = 0x1
 	RLIMIT_AS                        = 0x9
 	RLIMIT_MEMLOCK                   = 0x8
 	RLIMIT_NOFILE                    = 0x7

--- a/unix/zsysnum_linux_386.go
+++ b/unix/zsysnum_linux_386.go
@@ -447,4 +447,5 @@ const (
 	SYS_FUTEX_WAITV                  = 449
 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
 	SYS_CACHESTAT                    = 451
+	SYS_FCHMODAT2                    = 452
 )

--- a/unix/zsysnum_linux_amd64.go
+++ b/unix/zsysnum_linux_amd64.go
@@ -369,4 +369,6 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
+	SYS_MAP_SHADOW_STACK        = 453
 )

--- a/unix/zsysnum_linux_arm.go
+++ b/unix/zsysnum_linux_arm.go
@@ -411,4 +411,5 @@ const (
 	SYS_FUTEX_WAITV                  = 449
 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
 	SYS_CACHESTAT                    = 451
+	SYS_FCHMODAT2                    = 452
 )

--- a/unix/zsysnum_linux_arm64.go
+++ b/unix/zsysnum_linux_arm64.go
@@ -314,4 +314,5 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
 )

--- a/unix/zsysnum_linux_loong64.go
+++ b/unix/zsysnum_linux_loong64.go
@@ -308,4 +308,5 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
 )

--- a/unix/zsysnum_linux_mips.go
+++ b/unix/zsysnum_linux_mips.go
@@ -431,4 +431,5 @@ const (
 	SYS_FUTEX_WAITV                  = 4449
 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
 	SYS_CACHESTAT                    = 4451
+	SYS_FCHMODAT2                    = 4452
 )

--- a/unix/zsysnum_linux_mips64.go
+++ b/unix/zsysnum_linux_mips64.go
@@ -361,4 +361,5 @@ const (
 	SYS_FUTEX_WAITV             = 5449
 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
 	SYS_CACHESTAT               = 5451
+	SYS_FCHMODAT2               = 5452
 )

--- a/unix/zsysnum_linux_mips64le.go
+++ b/unix/zsysnum_linux_mips64le.go
@@ -361,4 +361,5 @@ const (
 	SYS_FUTEX_WAITV             = 5449
 	SYS_SET_MEMPOLICY_HOME_NODE = 5450
 	SYS_CACHESTAT               = 5451
+	SYS_FCHMODAT2               = 5452
 )

--- a/unix/zsysnum_linux_mipsle.go
+++ b/unix/zsysnum_linux_mipsle.go
@@ -431,4 +431,5 @@ const (
 	SYS_FUTEX_WAITV                  = 4449
 	SYS_SET_MEMPOLICY_HOME_NODE      = 4450
 	SYS_CACHESTAT                    = 4451
+	SYS_FCHMODAT2                    = 4452
 )

--- a/unix/zsysnum_linux_ppc.go
+++ b/unix/zsysnum_linux_ppc.go
@@ -438,4 +438,5 @@ const (
 	SYS_FUTEX_WAITV                  = 449
 	SYS_SET_MEMPOLICY_HOME_NODE      = 450
 	SYS_CACHESTAT                    = 451
+	SYS_FCHMODAT2                    = 452
 )

--- a/unix/zsysnum_linux_ppc64.go
+++ b/unix/zsysnum_linux_ppc64.go
@@ -410,4 +410,5 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
 )

--- a/unix/zsysnum_linux_ppc64le.go
+++ b/unix/zsysnum_linux_ppc64le.go
@@ -410,4 +410,5 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
 )

--- a/unix/zsysnum_linux_riscv64.go
+++ b/unix/zsysnum_linux_riscv64.go
@@ -315,4 +315,5 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
 )

--- a/unix/zsysnum_linux_s390x.go
+++ b/unix/zsysnum_linux_s390x.go
@@ -376,4 +376,5 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
 )

--- a/unix/zsysnum_linux_sparc64.go
+++ b/unix/zsysnum_linux_sparc64.go
@@ -389,4 +389,5 @@ const (
 	SYS_FUTEX_WAITV             = 449
 	SYS_SET_MEMPOLICY_HOME_NODE = 450
 	SYS_CACHESTAT               = 451
+	SYS_FCHMODAT2               = 452
 )


### PR DESCRIPTION
Update the Dockerfile to clone Linux v6.6 and commit the
changes generated by GOOS=linux ./mkall.sh.

Fixes golang/go#63833