### PR TITLE
x/sys/unix/linux: update glibc to 2.38

### DIFF
--- a/unix/linux/Dockerfile
+++ b/unix/linux/Dockerfile
@@ -17,8 +17,8 @@ WORKDIR /git
 RUN git config --global advice.detachedHead false
 # Linux Kernel: Released 30 October 2023
 RUN git clone --branch v6.6 --depth 1 https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux
-# GNU C library: Released 1 Feb 2023
-RUN git clone --branch release/2.37/master --depth 1 https://sourceware.org/git/glibc.git
+# GNU C library: Released 31 July 2023
+RUN git clone --branch release/2.38/master --depth 1 https://sourceware.org/git/glibc.git
 
 # Get Go
 ENV GOLANG_VERSION 1.21.0

--- a/unix/linux/mkall.go
+++ b/unix/linux/mkall.go
@@ -417,6 +417,14 @@ func (t *target) makeHeaders() error {
 	} else {
 		glibcArgs = append(glibcArgs, "--enable-kernel="+MinKernel)
 	}
+
+	if t.LinuxArch == "arm64" {
+		// glibc 2.38 requires libmvec to be disabled explicitly in aarch64
+		// since the compiler does not have SVE ACLE.
+		// See https://sourceware.org/pipermail/libc-alpha/2023-May/147829.html
+		glibcArgs = append(glibcArgs, "--disable-mathvec")
+	}
+
 	glibcConf := t.makeCommand(confScript, glibcArgs...)
 
 	glibcConf.Dir = buildDir

--- a/unix/zerrors_linux.go
+++ b/unix/zerrors_linux.go
@@ -1627,6 +1627,7 @@ const (
 	IP_FREEBIND                                 = 0xf
 	IP_HDRINCL                                  = 0x3
 	IP_IPSEC_POLICY                             = 0x10
+	IP_LOCAL_PORT_RANGE                         = 0x33
 	IP_MAXPACKET                                = 0xffff
 	IP_MAX_MEMBERSHIPS                          = 0x14
 	IP_MF                                       = 0x2000


### PR DESCRIPTION
Had to apply a small fix for aarch64, seems like libmvec is wrongly
enabled by default in aarch64, which causes mkall to fail since the
compiler does not have SVE ACLE.
