### PR TITLE
unix: remove extra trailing newlines in zsyscall_openbsd_*.go

### DIFF
--- a/unix/zsyscall_openbsd_386.go
+++ b/unix/zsyscall_openbsd_386.go
@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
 var libc_unveil_trampoline_addr uintptr
 
 //go:cgo_import_dynamic libc_unveil unveil "libc.so"
-
-

--- a/unix/zsyscall_openbsd_amd64.go
+++ b/unix/zsyscall_openbsd_amd64.go
@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
 var libc_unveil_trampoline_addr uintptr
 
 //go:cgo_import_dynamic libc_unveil unveil "libc.so"
-
-

--- a/unix/zsyscall_openbsd_arm.go
+++ b/unix/zsyscall_openbsd_arm.go
@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
 var libc_unveil_trampoline_addr uintptr
 
 //go:cgo_import_dynamic libc_unveil unveil "libc.so"
-
-

--- a/unix/zsyscall_openbsd_arm64.go
+++ b/unix/zsyscall_openbsd_arm64.go
@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
 var libc_unveil_trampoline_addr uintptr
 
 //go:cgo_import_dynamic libc_unveil unveil "libc.so"
-
-

--- a/unix/zsyscall_openbsd_mips64.go
+++ b/unix/zsyscall_openbsd_mips64.go
@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
 var libc_unveil_trampoline_addr uintptr
 
 //go:cgo_import_dynamic libc_unveil unveil "libc.so"
-
-

--- a/unix/zsyscall_openbsd_ppc64.go
+++ b/unix/zsyscall_openbsd_ppc64.go
@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
 var libc_unveil_trampoline_addr uintptr
 
 //go:cgo_import_dynamic libc_unveil unveil "libc.so"
-
-

--- a/unix/zsyscall_openbsd_riscv64.go
+++ b/unix/zsyscall_openbsd_riscv64.go
@@ -2297,5 +2297,3 @@ func unveil(path *byte, flags *byte) (err error) {
 var libc_unveil_trampoline_addr uintptr
 
 //go:cgo_import_dynamic libc_unveil unveil "libc.so"
-
-


### PR DESCRIPTION
These newlines are written by mksyscall.go but should not appear in the final
generated files once the output is passed through gofmt.  This is done by
mkall.sh but I had written a custom script just to generate these openbsd
zsyscall files in CL 468095.

Running the mksyscall.go output through gofmt fixes this issue.

Fixes golang/go#64820