### PR TITLE
unix: expose mmap calls on z/OS

### DIFF
--- a/unix/mmap_nomremap.go
+++ b/unix/mmap_nomremap.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || darwin || dragonfly || freebsd || openbsd || solaris
+//go:build aix || darwin || dragonfly || freebsd || openbsd || solaris || zos
 
 package unix
 

--- a/unix/syscall_zos_s390x.go
+++ b/unix/syscall_zos_s390x.go
@@ -1520,6 +1520,14 @@ func (m *mmapper) Munmap(data []byte) (err error) {
 	return nil
 }
 
+func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+        return mapper.Mmap(fd, offset, length, prot, flags)
+}
+
+func Munmap(b []byte) (err error) {
+        return mapper.Munmap(b)
+}
+
 func Read(fd int, p []byte) (n int, err error) {
 	n, err = read(fd, p)
 	if raceenabled {


### PR DESCRIPTION
The calls `Mmap` and `Munmap` were removed for z/OS.

This change exposes them in a z/OS specific file (to remove the accidental deletion of them in future refactors of the APIs for `unix-like` OSes).