### PR TITLE
windows: add GetKeyboardLayout & ToUnicodeEx

### DIFF
--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -17,8 +17,10 @@ import (
 	"unsafe"
 )
 
-type Handle uintptr
-type HWND uintptr
+type (
+	Handle uintptr
+	HWND   uintptr
+)
 
 const (
 	InvalidHandle = ^Handle(0)
@@ -211,6 +213,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 //sys	OpenProcess(desiredAccess uint32, inheritHandle bool, processId uint32) (handle Handle, err error)
 //sys	ShellExecute(hwnd Handle, verb *uint16, file *uint16, args *uint16, cwd *uint16, showCmd int32) (err error) [failretval<=32] = shell32.ShellExecuteW
 //sys	GetWindowThreadProcessId(hwnd HWND, pid *uint32) (tid uint32, err error) = user32.GetWindowThreadProcessId
+//sys	GetKeyboardLayout(tid uint32) (hkl Handle) = user32.GetKeyboardLayout
+//sys	toUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) = user32.ToUnicodeEx
 //sys	GetShellWindow() (shellWindow HWND) = user32.GetShellWindow
 //sys	MessageBox(hwnd HWND, text *uint16, caption *uint16, boxtype uint32) (ret int32, err error) [failretval==0] = user32.MessageBoxW
 //sys	ExitWindowsEx(flags uint32, reason uint32) (err error) = user32.ExitWindowsEx
@@ -1368,9 +1372,11 @@ func SetsockoptLinger(fd Handle, level, opt int, l *Linger) (err error) {
 func SetsockoptInet4Addr(fd Handle, level, opt int, value [4]byte) (err error) {
 	return Setsockopt(fd, int32(level), int32(opt), (*byte)(unsafe.Pointer(&value[0])), 4)
 }
+
 func SetsockoptIPMreq(fd Handle, level, opt int, mreq *IPMreq) (err error) {
 	return Setsockopt(fd, int32(level), int32(opt), (*byte)(unsafe.Pointer(mreq)), int32(unsafe.Sizeof(*mreq)))
 }
+
 func SetsockoptIPv6Mreq(fd Handle, level, opt int, mreq *IPv6Mreq) (err error) {
 	return syscall.EWINDOWS
 }
@@ -1916,3 +1922,13 @@ const (
 	EV_ERR     = 0x0080
 	EV_RING    = 0x0100
 )
+
+// ToUnicodeEx Translates the specified virtual-key code and keyboard state to
+// the corresponding Unicode character or characters.
+func ToUnicodeEx(virtualKey, scanCode uint32, buf []uint16, flags uint32, layout Handle) int32 {
+	if len(buf) == 0 {
+		return 0
+	}
+	var keyState [256]byte
+	return toUnicodeEx(virtualKey, scanCode, &keyState[0], &buf[0], int32(len(buf)), flags, layout)
+}

--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -1925,10 +1925,9 @@ const (
 
 // ToUnicodeEx Translates the specified virtual-key code and keyboard state to
 // the corresponding Unicode character or characters.
-func ToUnicodeEx(virtualKey, scanCode uint32, buf []uint16, flags uint32, layout Handle) int32 {
+func ToUnicodeEx(virtualKey, scanCode uint32, keyState [256]byte, buf []uint16, flags uint32, layout Handle) int32 {
 	if len(buf) == 0 {
 		return 0
 	}
-	var keyState [256]byte
 	return toUnicodeEx(virtualKey, scanCode, &keyState[0], &buf[0], int32(len(buf)), flags, layout)
 }

--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -216,7 +216,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 //sys	LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle) = user32.LoadKeyboardLayoutW
 //sys	UnloadKeyboardLayout(hkl Handle) (v bool) = user32.UnloadKeyboardLayout
 //sys	GetKeyboardLayout(tid uint32) (hkl Handle) = user32.GetKeyboardLayout
-//sys	toUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) = user32.ToUnicodeEx
+//sys	ToUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) = user32.ToUnicodeEx
 //sys	GetShellWindow() (shellWindow HWND) = user32.GetShellWindow
 //sys	MessageBox(hwnd HWND, text *uint16, caption *uint16, boxtype uint32) (ret int32, err error) [failretval==0] = user32.MessageBoxW
 //sys	ExitWindowsEx(flags uint32, reason uint32) (err error) = user32.ExitWindowsEx
@@ -1924,12 +1924,3 @@ const (
 	EV_ERR     = 0x0080
 	EV_RING    = 0x0100
 )
-
-// ToUnicodeEx Translates the specified virtual-key code and keyboard state to
-// the corresponding Unicode character or characters.
-func ToUnicodeEx(virtualKey, scanCode uint32, keyState [256]byte, buf []uint16, flags uint32, layout Handle) int32 {
-	if len(buf) == 0 {
-		return 0
-	}
-	return toUnicodeEx(virtualKey, scanCode, &keyState[0], &buf[0], int32(len(buf)), flags, layout)
-}

--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -213,8 +213,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 //sys	OpenProcess(desiredAccess uint32, inheritHandle bool, processId uint32) (handle Handle, err error)
 //sys	ShellExecute(hwnd Handle, verb *uint16, file *uint16, args *uint16, cwd *uint16, showCmd int32) (err error) [failretval<=32] = shell32.ShellExecuteW
 //sys	GetWindowThreadProcessId(hwnd HWND, pid *uint32) (tid uint32, err error) = user32.GetWindowThreadProcessId
-//sys	LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle) = user32.LoadKeyboardLayoutW
-//sys	UnloadKeyboardLayout(hkl Handle) (v bool) = user32.UnloadKeyboardLayout
+//sys	LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle, err error) [failretval==0] = user32.LoadKeyboardLayoutW
+//sys	UnloadKeyboardLayout(hkl Handle) (err error) = user32.UnloadKeyboardLayout
 //sys	GetKeyboardLayout(tid uint32) (hkl Handle) = user32.GetKeyboardLayout
 //sys	ToUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) = user32.ToUnicodeEx
 //sys	GetShellWindow() (shellWindow HWND) = user32.GetShellWindow

--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -213,6 +213,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 //sys	OpenProcess(desiredAccess uint32, inheritHandle bool, processId uint32) (handle Handle, err error)
 //sys	ShellExecute(hwnd Handle, verb *uint16, file *uint16, args *uint16, cwd *uint16, showCmd int32) (err error) [failretval<=32] = shell32.ShellExecuteW
 //sys	GetWindowThreadProcessId(hwnd HWND, pid *uint32) (tid uint32, err error) = user32.GetWindowThreadProcessId
+//sys	LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle) = user32.LoadKeyboardLayoutW
+//sys	UnloadKeyboardLayout(hkl Handle) (v bool) = user32.UnloadKeyboardLayout
 //sys	GetKeyboardLayout(tid uint32) (hkl Handle) = user32.GetKeyboardLayout
 //sys	toUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) = user32.ToUnicodeEx
 //sys	GetShellWindow() (shellWindow HWND) = user32.GetShellWindow

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -1293,7 +1293,7 @@ func TestToUnicodeEx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UTF16PtrFromString failed: %v", err)
 	}
-	araLayout := windows.LoadKeyboardLayout(ara, 0)
+	araLayout := windows.LoadKeyboardLayout(ara, windows.KLF_ACTIVATE)
 	var keyState [256]byte
 	ret := windows.ToUnicodeEx(
 		0x41, // 'A' vkCode

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -1283,17 +1283,20 @@ func TestGetKeyboardLayout(t *testing.T) {
 		t.Fatalf("GetWindowThreadProcessId failed: %v", err)
 	}
 
+	// We don't care about the result, just that it doesn't crash.
 	_ = windows.GetKeyboardLayout(tid)
 }
 
 func TestToUnicodeEx(t *testing.T) {
 	var utf16Buf [16]uint16
 	const araLayout = windows.Handle(0x401)
+	var keyState [256]byte
 	ret := windows.ToUnicodeEx(
 		0x41, // 'A' vkCode
 		0x1e, // 'A' scanCode
+		keyState,
 		utf16Buf[:],
-		0,
+		0x4, // don't change keyboard state
 		araLayout,
 	)
 

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -1289,11 +1289,18 @@ func TestGetKeyboardLayout(t *testing.T) {
 
 func TestToUnicodeEx(t *testing.T) {
 	var utf16Buf [16]uint16
-	ara, err := windows.UTF16PtrFromString("00000401") // ara layout 0x401
+
+	// Arabic (101) Keyboard Identifier
+	// See https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-language-pack-default-values
+	ara, err := windows.UTF16PtrFromString("00000401")
 	if err != nil {
 		t.Fatalf("UTF16PtrFromString failed: %v", err)
 	}
-	araLayout := windows.LoadKeyboardLayout(ara, windows.KLF_ACTIVATE)
+	araLayout, err := windows.LoadKeyboardLayout(ara, windows.KLF_ACTIVATE)
+	if err != nil {
+		t.Fatalf("LoadKeyboardLayout failed: %v", err)
+	}
+
 	var keyState [256]byte
 	ret := windows.ToUnicodeEx(
 		0x41, // 'A' vkCode
@@ -1311,7 +1318,7 @@ func TestToUnicodeEx(t *testing.T) {
 	if utf16Buf[0] != 'ش' {
 		t.Errorf("ToUnicodeEx failed, wanted 'ش', got %q", utf16Buf[0])
 	}
-	if !windows.UnloadKeyboardLayout(araLayout) {
-		t.Errorf("UnloadKeyboardLayout failed")
+	if err := windows.UnloadKeyboardLayout(araLayout); err != nil {
+		t.Errorf("UnloadKeyboardLayout failed: %v", err)
 	}
 }

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -1275,3 +1275,32 @@ uintptr_t beep(void) {
 		t.Fatal("LoadLibraryEx unexpectedly found beep.dll")
 	}
 }
+
+func TestGetKeyboardLayout(t *testing.T) {
+	fg := windows.GetForegroundWindow()
+	tid, err := windows.GetWindowThreadProcessId(fg, nil)
+	if err != nil {
+		t.Fatalf("GetWindowThreadProcessId failed: %v", err)
+	}
+
+	_ = windows.GetKeyboardLayout(tid)
+}
+
+func TestToUnicodeEx(t *testing.T) {
+	var utf16Buf [16]uint16
+	const araLayout = windows.Handle(0x401)
+	ret := windows.ToUnicodeEx(
+		0x41, // 'A' vkCode
+		0x1e, // 'A' scanCode
+		utf16Buf[:],
+		0,
+		araLayout,
+	)
+
+	if ret != 1 {
+		t.Errorf("ToUnicodeEx failed, wanted 1, got %d", ret)
+	}
+	if utf16Buf[0] != 'ش' {
+		t.Errorf("ToUnicodeEx failed, wanted 'ش', got %q", utf16Buf[0])
+	}
+}

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -1289,13 +1289,18 @@ func TestGetKeyboardLayout(t *testing.T) {
 
 func TestToUnicodeEx(t *testing.T) {
 	var utf16Buf [16]uint16
-	const araLayout = windows.Handle(0x401)
+	ara, err := windows.UTF16PtrFromString("00000401") // ara layout 0x401
+	if err != nil {
+		t.Fatalf("UTF16PtrFromString failed: %v", err)
+	}
+	araLayout := windows.LoadKeyboardLayout(ara, 0)
 	var keyState [256]byte
 	ret := windows.ToUnicodeEx(
 		0x41, // 'A' vkCode
 		0x1e, // 'A' scanCode
-		keyState,
-		utf16Buf[:],
+		&keyState[0],
+		&utf16Buf[0],
+		int32(len(utf16Buf)),
 		0x4, // don't change keyboard state
 		araLayout,
 	)
@@ -1305,5 +1310,8 @@ func TestToUnicodeEx(t *testing.T) {
 	}
 	if utf16Buf[0] != 'ش' {
 		t.Errorf("ToUnicodeEx failed, wanted 'ش', got %q", utf16Buf[0])
+	}
+	if !windows.UnloadKeyboardLayout(araLayout) {
+		t.Errorf("UnloadKeyboardLayout failed")
 	}
 }

--- a/windows/types_windows.go
+++ b/windows/types_windows.go
@@ -3404,3 +3404,14 @@ type DCB struct {
 	EvtChar    byte
 	wReserved1 uint16
 }
+
+// Keyboard Layout Flags.
+// See https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadkeyboardlayoutw
+const (
+	KLF_ACTIVATE      = 0x00000001
+	KLF_SUBSTITUTE_OK = 0x00000002
+	KLF_REORDER       = 0x00000008
+	KLF_REPLACELANG   = 0x00000010
+	KLF_NOTELLSHELL   = 0x00000080
+	KLF_SETFORPROCESS = 0x00000100
+)

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -4116,9 +4116,12 @@ func IsWindowVisible(hwnd HWND) (isVisible bool) {
 	return
 }
 
-func LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle) {
-	r0, _, _ := syscall.Syscall(procLoadKeyboardLayoutW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(flags), 0)
+func LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle, err error) {
+	r0, _, e1 := syscall.Syscall(procLoadKeyboardLayoutW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(flags), 0)
 	hkl = Handle(r0)
+	if hkl == 0 {
+		err = errnoErr(e1)
+	}
 	return
 }
 
@@ -4137,9 +4140,11 @@ func ToUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16,
 	return
 }
 
-func UnloadKeyboardLayout(hkl Handle) (v bool) {
-	r0, _, _ := syscall.Syscall(procUnloadKeyboardLayout.Addr(), 1, uintptr(hkl), 0, 0)
-	v = r0 != 0
+func UnloadKeyboardLayout(hkl Handle) (err error) {
+	r1, _, e1 := syscall.Syscall(procUnloadKeyboardLayout.Addr(), 1, uintptr(hkl), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
 	return
 }
 

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -4131,7 +4131,7 @@ func MessageBox(hwnd HWND, text *uint16, caption *uint16, boxtype uint32) (ret i
 	return
 }
 
-func toUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) {
+func ToUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) {
 	r0, _, _ := syscall.Syscall9(procToUnicodeEx.Addr(), 7, uintptr(vkey), uintptr(scancode), uintptr(unsafe.Pointer(keystate)), uintptr(unsafe.Pointer(pwszBuff)), uintptr(cchBuff), uintptr(flags), uintptr(hkl), 0, 0)
 	ret = int32(r0)
 	return

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -483,8 +483,10 @@ var (
 	procIsWindow                                             = moduser32.NewProc("IsWindow")
 	procIsWindowUnicode                                      = moduser32.NewProc("IsWindowUnicode")
 	procIsWindowVisible                                      = moduser32.NewProc("IsWindowVisible")
+	procLoadKeyboardLayoutW                                  = moduser32.NewProc("LoadKeyboardLayoutW")
 	procMessageBoxW                                          = moduser32.NewProc("MessageBoxW")
 	procToUnicodeEx                                          = moduser32.NewProc("ToUnicodeEx")
+	procUnloadKeyboardLayout                                 = moduser32.NewProc("UnloadKeyboardLayout")
 	procCreateEnvironmentBlock                               = moduserenv.NewProc("CreateEnvironmentBlock")
 	procDestroyEnvironmentBlock                              = moduserenv.NewProc("DestroyEnvironmentBlock")
 	procGetUserProfileDirectoryW                             = moduserenv.NewProc("GetUserProfileDirectoryW")
@@ -4114,6 +4116,12 @@ func IsWindowVisible(hwnd HWND) (isVisible bool) {
 	return
 }
 
+func LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle) {
+	r0, _, _ := syscall.Syscall(procLoadKeyboardLayoutW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(flags), 0)
+	hkl = Handle(r0)
+	return
+}
+
 func MessageBox(hwnd HWND, text *uint16, caption *uint16, boxtype uint32) (ret int32, err error) {
 	r0, _, e1 := syscall.Syscall6(procMessageBoxW.Addr(), 4, uintptr(hwnd), uintptr(unsafe.Pointer(text)), uintptr(unsafe.Pointer(caption)), uintptr(boxtype), 0, 0)
 	ret = int32(r0)
@@ -4126,6 +4134,12 @@ func MessageBox(hwnd HWND, text *uint16, caption *uint16, boxtype uint32) (ret i
 func toUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) {
 	r0, _, _ := syscall.Syscall9(procToUnicodeEx.Addr(), 7, uintptr(vkey), uintptr(scancode), uintptr(unsafe.Pointer(keystate)), uintptr(unsafe.Pointer(pwszBuff)), uintptr(cchBuff), uintptr(flags), uintptr(hkl), 0, 0)
 	ret = int32(r0)
+	return
+}
+
+func UnloadKeyboardLayout(hkl Handle) (v bool) {
+	r0, _, _ := syscall.Syscall(procUnloadKeyboardLayout.Addr(), 1, uintptr(hkl), 0, 0)
+	v = r0 != 0
 	return
 }
 

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -477,12 +477,14 @@ var (
 	procGetDesktopWindow                                     = moduser32.NewProc("GetDesktopWindow")
 	procGetForegroundWindow                                  = moduser32.NewProc("GetForegroundWindow")
 	procGetGUIThreadInfo                                     = moduser32.NewProc("GetGUIThreadInfo")
+	procGetKeyboardLayout                                    = moduser32.NewProc("GetKeyboardLayout")
 	procGetShellWindow                                       = moduser32.NewProc("GetShellWindow")
 	procGetWindowThreadProcessId                             = moduser32.NewProc("GetWindowThreadProcessId")
 	procIsWindow                                             = moduser32.NewProc("IsWindow")
 	procIsWindowUnicode                                      = moduser32.NewProc("IsWindowUnicode")
 	procIsWindowVisible                                      = moduser32.NewProc("IsWindowVisible")
 	procMessageBoxW                                          = moduser32.NewProc("MessageBoxW")
+	procToUnicodeEx                                          = moduser32.NewProc("ToUnicodeEx")
 	procCreateEnvironmentBlock                               = moduserenv.NewProc("CreateEnvironmentBlock")
 	procDestroyEnvironmentBlock                              = moduserenv.NewProc("DestroyEnvironmentBlock")
 	procGetUserProfileDirectoryW                             = moduserenv.NewProc("GetUserProfileDirectoryW")
@@ -4073,6 +4075,12 @@ func GetGUIThreadInfo(thread uint32, info *GUIThreadInfo) (err error) {
 	return
 }
 
+func GetKeyboardLayout(tid uint32) (hkl Handle) {
+	r0, _, _ := syscall.Syscall(procGetKeyboardLayout.Addr(), 1, uintptr(tid), 0, 0)
+	hkl = Handle(r0)
+	return
+}
+
 func GetShellWindow() (shellWindow HWND) {
 	r0, _, _ := syscall.Syscall(procGetShellWindow.Addr(), 0, 0, 0, 0)
 	shellWindow = HWND(r0)
@@ -4112,6 +4120,12 @@ func MessageBox(hwnd HWND, text *uint16, caption *uint16, boxtype uint32) (ret i
 	if ret == 0 {
 		err = errnoErr(e1)
 	}
+	return
+}
+
+func toUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) {
+	r0, _, _ := syscall.Syscall9(procToUnicodeEx.Addr(), 7, uintptr(vkey), uintptr(scancode), uintptr(unsafe.Pointer(keystate)), uintptr(unsafe.Pointer(pwszBuff)), uintptr(cchBuff), uintptr(flags), uintptr(hkl), 0, 0)
+	ret = int32(r0)
 	return
 }
 


### PR DESCRIPTION
These are used along with GetForegroundWindow and GetWindowThreadProcessId to determine the current user layout and translate the base key the user has pressed.