### PR TITLE
unix: fix IoctlGetPtmget get empty ptsname on NetBSD.

### DIFF
--- a/unix/syscall_netbsd_test.go
+++ b/unix/syscall_netbsd_test.go
@@ -38,7 +38,12 @@ func TestIoctlPtmget(t *testing.T) {
 		t.Fatalf("IoctlGetPtmget: %v\n", err)
 	}
 
-	t.Logf("sfd = %v, ptsname = %v", ptm.Sfd, unix.ByteSliceToString(ptm.Sn[:]))
+	ptsname := unix.ByteSliceToString(ptm.Sn[:])
+	if ptsname == "" {
+		t.Fatalf("IoctlGetPtmget: ptsname is empty string\n")
+	}
+
+	t.Logf("sfd = %v, ptsname = %v", ptm.Sfd, ptsname)
 }
 
 func TestStatvfs(t *testing.T) {

--- a/unix/ztypes_netbsd_386.go
+++ b/unix/ztypes_netbsd_386.go
@@ -438,8 +438,8 @@ type Winsize struct {
 type Ptmget struct {
 	Cfd int32
 	Sfd int32
-	Cn  [1024]byte
-	Sn  [1024]byte
+	Cn  [16]byte
+	Sn  [16]byte
 }
 
 const (

--- a/unix/ztypes_netbsd_amd64.go
+++ b/unix/ztypes_netbsd_amd64.go
@@ -446,8 +446,8 @@ type Winsize struct {
 type Ptmget struct {
 	Cfd int32
 	Sfd int32
-	Cn  [1024]byte
-	Sn  [1024]byte
+	Cn  [16]byte
+	Sn  [16]byte
 }
 
 const (

--- a/unix/ztypes_netbsd_arm64.go
+++ b/unix/ztypes_netbsd_arm64.go
@@ -446,8 +446,8 @@ type Winsize struct {
 type Ptmget struct {
 	Cfd int32
 	Sfd int32
-	Cn  [1024]byte
-	Sn  [1024]byte
+	Cn  [16]byte
+	Sn  [16]byte
 }
 
 const (


### PR DESCRIPTION
On NetBSD, because the size of the Ptmget structure does not match the value of TIOCPTSNAME, IoctlGetPtmget uses an incorrect structure internally, resulting in empty ptsname.

See https://github.com/NetBSD/src/blob/trunk/sys/sys/ttycom.h

Fixes #66871