### PR TITLE
unix: add unsafe mmap, munmap, mremap

### DIFF
--- a/unix/mremap.go
+++ b/unix/mremap.go
@@ -50,3 +50,8 @@ func (m *mremapMmapper) Mremap(oldData []byte, newLength int, flags int) (data [
 func Mremap(oldData []byte, newLength int, flags int) (data []byte, err error) {
 	return mapper.Mremap(oldData, newLength, flags)
 }
+
+func MremapPtr(oldAddr unsafe.Pointer, oldSize uintptr, newAddr unsafe.Pointer, newSize uintptr, flags int) (ret unsafe.Pointer, err error) {
+	xaddr, err := mapper.mremap(uintptr(oldAddr), oldSize, newSize, flags, uintptr(newAddr))
+	return unsafe.Pointer(xaddr), err
+}

--- a/unix/mremap_test.go
+++ b/unix/mremap_test.go
@@ -8,6 +8,7 @@ package unix_test
 
 import (
 	"testing"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -42,5 +43,34 @@ func TestMremap(t *testing.T) {
 	_, err = unix.Mremap(b, unix.Getpagesize(), unix.MremapFixed)
 	if err != unix.EINVAL {
 		t.Fatalf("remapping to a fixed address; got %v, want %v", err, unix.EINVAL)
+	}
+}
+
+func TestMremapPtr(t *testing.T) {
+	mmapProt := unix.PROT_NONE
+	mmapPtrProt := unix.PROT_READ | unix.PROT_WRITE
+	b, err := unix.Mmap(-1, 0, 2*unix.Getpagesize(), mmapProt, unix.MAP_ANON|unix.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("Mmap: %v", err)
+	}
+	if _, err := unix.MmapPtr(-1, 0, unsafe.Pointer(&b[0]), uintptr(unix.Getpagesize()),
+		mmapPtrProt, unix.MAP_ANON|unix.MAP_PRIVATE|unix.MAP_FIXED); err != nil {
+		t.Fatalf("MmapPtr: %v", err)
+	}
+
+	b[0] = 42
+
+	if _, err := unix.MremapPtr(
+		unsafe.Pointer(&b[0]), uintptr(unix.Getpagesize()),
+		unsafe.Pointer(&b[unix.Getpagesize()]), uintptr(unix.Getpagesize()),
+		unix.MremapFixed|unix.MremapMaymove); err != nil {
+		t.Fatalf("MremapPtr: %v", err)
+	}
+	if got := b[unix.Getpagesize()]; got != 42 {
+		t.Errorf("got %d, want 42", got)
+	}
+
+	if err := unix.Munmap(b); err != nil {
+		t.Fatalf("Munmap: %v", err)
 	}
 }

--- a/unix/syscall_unix.go
+++ b/unix/syscall_unix.go
@@ -154,6 +154,15 @@ func Munmap(b []byte) (err error) {
 	return mapper.Munmap(b)
 }
 
+func MmapPtr(addr unsafe.Pointer, length uintptr, prot int, flags int, fd int, offset int64) (ret unsafe.Pointer, err error) {
+	xaddr, err := mapper.mmap(uintptr(addr), length, prot, flags, fd, offset)
+	return unsafe.Pointer(xaddr), err
+}
+
+func MunmapPtr(addr unsafe.Pointer, length uintptr) (err error) {
+	return mapper.munmap(uintptr(addr), length)
+}
+
 func Read(fd int, p []byte) (n int, err error) {
 	n, err = read(fd, p)
 	if raceenabled {

--- a/unix/syscall_unix.go
+++ b/unix/syscall_unix.go
@@ -154,7 +154,7 @@ func Munmap(b []byte) (err error) {
 	return mapper.Munmap(b)
 }
 
-func MmapPtr(addr unsafe.Pointer, length uintptr, prot int, flags int, fd int, offset int64) (ret unsafe.Pointer, err error) {
+func MmapPtr(fd int, offset int64, addr unsafe.Pointer, length uintptr, prot int, flags int) (ret unsafe.Pointer, err error) {
 	xaddr, err := mapper.mmap(uintptr(addr), length, prot, flags, fd, offset)
 	return unsafe.Pointer(xaddr), err
 }


### PR DESCRIPTION
Fixes golang/go#56123