### PR TITLE
windows: add SIO_UDP_NETRESET for net/ to use

### DIFF
--- a/windows/types_windows.go
+++ b/windows/types_windows.go
@@ -1060,6 +1060,7 @@ const (
 	SIO_GET_EXTENSION_FUNCTION_POINTER = IOC_INOUT | IOC_WS2 | 6
 	SIO_KEEPALIVE_VALS                 = IOC_IN | IOC_VENDOR | 4
 	SIO_UDP_CONNRESET                  = IOC_IN | IOC_VENDOR | 12
+	SIO_UDP_NETRESET                   = IOC_IN | IOC_VENDOR | 15
 
 	// cf. http://support.microsoft.com/default.aspx?scid=kb;en-us;257460
 


### PR DESCRIPTION
In order to get BSD like behavior with regard to ICMP, it is necessary to set SIO_UDP_NETRESET as well as SIO_UDP_CONNRESET.

For golang/go#68614