### PR TITLE
x/sys/unix: add missing ETHTOOL_FLAG_ constants

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -3551,8 +3551,8 @@ const (
 
 // ethtool and its netlink interface, generated using:
 //
-// perl -nlE '/^\s*(ETHTOOL_\w+)/ && say "$1 = C.$1"' ethtool.h
-// perl -nlE '/^\s*(ETHTOOL_\w+)/ && say "$1 = C.$1"' ethtool_netlink.h
+// perl -nlE '/^\s*(ETHTOOL_\w+)/ && say "$1 = C.$1"' /usr/include/linux/ethtool.h
+// perl -nlE '/^\s*(ETHTOOL_\w+)/ && say "$1 = C.$1"' /usr/include/linux/ethtool_netlink.h
 //
 // Note that a couple of constants produced by this command will be duplicated
 // by mkerrors.sh, so some manual pruning was necessary.
@@ -3787,6 +3787,9 @@ const (
 	ETHTOOL_MSG_PSE_GET_REPLY                 = C.ETHTOOL_MSG_PSE_GET_REPLY
 	ETHTOOL_MSG_RSS_GET_REPLY                 = C.ETHTOOL_MSG_RSS_GET_REPLY
 	ETHTOOL_MSG_KERNEL_MAX                    = C.ETHTOOL_MSG_KERNEL_MAX
+	ETHTOOL_FLAG_COMPACT_BITSETS              = C.ETHTOOL_FLAG_COMPACT_BITSETS
+	ETHTOOL_FLAG_OMIT_REPLY                   = C.ETHTOOL_FLAG_OMIT_REPLY
+	ETHTOOL_FLAG_STATS                        = C.ETHTOOL_FLAG_STATS
 	ETHTOOL_A_HEADER_UNSPEC                   = C.ETHTOOL_A_HEADER_UNSPEC
 	ETHTOOL_A_HEADER_DEV_INDEX                = C.ETHTOOL_A_HEADER_DEV_INDEX
 	ETHTOOL_A_HEADER_DEV_NAME                 = C.ETHTOOL_A_HEADER_DEV_NAME

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -3807,6 +3807,9 @@ const (
 	ETHTOOL_MSG_PSE_GET_REPLY                 = 0x25
 	ETHTOOL_MSG_RSS_GET_REPLY                 = 0x26
 	ETHTOOL_MSG_KERNEL_MAX                    = 0x2b
+	ETHTOOL_FLAG_COMPACT_BITSETS              = 0x1
+	ETHTOOL_FLAG_OMIT_REPLY                   = 0x2
+	ETHTOOL_FLAG_STATS                        = 0x4
 	ETHTOOL_A_HEADER_UNSPEC                   = 0x0
 	ETHTOOL_A_HEADER_DEV_INDEX                = 0x1
 	ETHTOOL_A_HEADER_DEV_NAME                 = 0x2


### PR DESCRIPTION
Some constants were removed in CL 600516 that included changes for the 
Linux kernel 6.10.

This kernel version moved C defines to an enum ethtool_header_flags that
was not picked up by the mkall.sh script.

For enums, there is a perl script that needs to be run manually, and the
output must be added by hand to the list of constants in unix/linux/types.go.

See https://elixir.bootlin.com/linux/v6.10.3/source/include/uapi/linux/ethtool_netlink.h#L120

Fixes golang/go#68761