### PR TITLE
unix: add f_flag member flags on z/OS

### DIFF
--- a/unix/zerrors_zos_s390x.go
+++ b/unix/zerrors_zos_s390x.go
@@ -581,6 +581,8 @@ const (
 	AT_EMPTY_PATH                   = 0x1000
 	AT_REMOVEDIR                    = 0x200
 	RENAME_NOREPLACE                = 1 << 0
+	ST_RDONLY                       = 1
+	ST_NOSUID                       = 2
 )
 
 const (


### PR DESCRIPTION
This change adds the constants `ST_RDONLY` and `ST_NOSUID` to a z/OS-specific file.