### PR TITLE
unix: fix grep syntax to work on non-GNU greps

### DIFF
--- a/unix/mkerrors.sh
+++ b/unix/mkerrors.sh
@@ -656,7 +656,7 @@ errors=$(
 signals=$(
 	echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print $2 }' |
-	grep -v 'SIGSTKSIZE\|SIGSTKSZ\|SIGRT\|SIGMAX64' |
+	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT|SIGMAX64)' |
 	sort
 )
 
@@ -666,7 +666,7 @@ echo '#include <errno.h>' | $CC -x c - -E -dM $ccflags |
 	sort >_error.grep
 echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
 	awk '$1=="#define" && $2 ~ /^SIG[A-Z0-9]+$/ { print "^\t" $2 "[ \t]*=" }' |
-	grep -v 'SIGSTKSIZE\|SIGSTKSZ\|SIGRT\|SIGMAX64' |
+	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT|SIGMAX64)' |
 	sort >_signal.grep
 
 echo '// mkerrors.sh' "$@"


### PR DESCRIPTION
CL 432835 changed two grep commands in unix/mkerrors.sh in such a way
that is incompatible with AIX's grep, which, unlike GNU grep, does not
support extended regular expressions without the -E flag. The intent of
this PR is to restore the egrep behavior by invoking grep as grep -E.
My assumption is that GNU grep is not meant to be a requirement to run
mkerrors.sh, and given that, grep -E looks like the most cross-platform
approach.

Example of current (incorrect) behavior on AIX:

bash-5.2$ printf 'SIGHUP\nSIGMAX64\nSIGTERM' | grep -v 'SIGSTKSIZE\|SIGSTKSZ\|SIGRT\|SIGMAX64' 
SIGHUP
SIGMAX64
SIGTERM


Behavior before CL 432835:

bash-5.2$ printf 'SIGHUP\nSIGMAX64\nSIGTERM' | egrep -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT|SIGMAX64)'
SIGHUP
SIGTERM


Behavior of proposed change:

bash-5.2$ printf 'SIGHUP\nSIGMAX64\nSIGTERM' | grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT|SIGMAX64)'
SIGHUP
SIGTERM


OpenBSD's grep behaves the same as AIX for the above commands, which is
why I cast this as GNU vs. non-GNU. I haven't tested any other
implementations.

Fixes golang/go#69365
