### PR TITLE
unix: mark vgetrandom as non-escaping

### DIFF
--- a/unix/vgetrandom_linux.go
+++ b/unix/vgetrandom_linux.go
@@ -9,4 +9,5 @@ package unix
 import _ "unsafe"
 
 //go:linkname vgetrandom runtime.vgetrandom
+//go:noescape
 func vgetrandom(p []byte, flags uint32) (ret int, supported bool)


### PR DESCRIPTION
For golang/go#69577