### PR TITLE
unix: add IoctlGetHwTstamp/IoctlGetHwTstamp on Linux

### DIFF
--- a/unix/ioctl_linux.go
+++ b/unix/ioctl_linux.go
@@ -73,6 +73,32 @@ func IoctlGetEthtoolTsInfo(fd int, ifname string) (*EthtoolTsInfo, error) {
 	return &value, err
 }
 
+// IoctlGetHwTstamp retrieves the hardware timestamping configuration
+// for the network device specified by ifname.
+func IoctlGetHwTstamp(fd int, ifname string) (*HwTstampConfig, error) {
+	ifr, err := NewIfreq(ifname)
+	if err != nil {
+		return nil, err
+	}
+
+	value := HwTstampConfig{}
+	ifrd := ifr.withData(unsafe.Pointer(&value))
+
+	err = ioctlIfreqData(fd, SIOCGHWTSTAMP, &ifrd)
+	return &value, err
+}
+
+// IoctlSetHwTstamp updates the hardware timestamping configuration for
+// the network device specified by ifname.
+func IoctlSetHwTstamp(fd int, ifname string, cfg *HwTstampConfig) error {
+	ifr, err := NewIfreq(ifname)
+	if err != nil {
+		return err
+	}
+	ifrd := ifr.withData(unsafe.Pointer(cfg))
+	return ioctlIfreqData(fd, SIOCSHWTSTAMP, &ifrd)
+}
+
 // IoctlGetWatchdogInfo fetches information about a watchdog device from the
 // Linux watchdog API. For more information, see:
 // https://www.kernel.org/doc/html/latest/watchdog/watchdog-api.html.

--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -144,6 +144,7 @@ struct termios2 {
 #include <linux/netfilter.h>
 #include <linux/netfilter_ipv4.h>
 #include <linux/netlink.h>
+#include <linux/net_tstamp.h>
 #include <linux/nexthop.h>
 #include <linux/nfc.h>
 #include <linux/nl80211.h>
@@ -4106,6 +4107,24 @@ const SPEED_UNKNOWN = C.SPEED_UNKNOWN
 type EthtoolDrvinfo C.struct_ethtool_drvinfo
 
 type EthtoolTsInfo C.struct_ethtool_ts_info
+
+type HwTstampConfig C.struct_hwtstamp_config
+
+const (
+	HWTSTAMP_FILTER_NONE            = C.HWTSTAMP_FILTER_NONE
+	HWTSTAMP_FILTER_ALL             = C.HWTSTAMP_FILTER_ALL
+	HWTSTAMP_FILTER_SOME            = C.HWTSTAMP_FILTER_SOME
+	HWTSTAMP_FILTER_PTP_V1_L4_EVENT = C.HWTSTAMP_FILTER_PTP_V1_L4_EVENT
+	HWTSTAMP_FILTER_PTP_V2_L4_EVENT = C.HWTSTAMP_FILTER_PTP_V2_L4_EVENT
+	HWTSTAMP_FILTER_PTP_V2_L2_EVENT = C.HWTSTAMP_FILTER_PTP_V2_L2_EVENT
+	HWTSTAMP_FILTER_PTP_V2_EVENT    = C.HWTSTAMP_FILTER_PTP_V2_EVENT
+)
+
+const (
+	HWTSTAMP_TX_OFF          = C.HWTSTAMP_TX_OFF
+	HWTSTAMP_TX_ON           = C.HWTSTAMP_TX_ON
+	HWTSTAMP_TX_ONESTEP_SYNC = C.HWTSTAMP_TX_ONESTEP_SYNC
+)
 
 type (
 	HIDRawReportDescriptor C.struct_hidraw_report_descriptor

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -4120,6 +4120,28 @@ type EthtoolTsInfo struct {
 	Rx_reserved     [3]uint32
 }
 
+type HwTstampConfig struct {
+	Flags     int32
+	Tx_type   int32
+	Rx_filter int32
+}
+
+const (
+	HWTSTAMP_FILTER_NONE            = 0x0
+	HWTSTAMP_FILTER_ALL             = 0x1
+	HWTSTAMP_FILTER_SOME            = 0x2
+	HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 0x3
+	HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 0x6
+	HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 0x9
+	HWTSTAMP_FILTER_PTP_V2_EVENT    = 0xc
+)
+
+const (
+	HWTSTAMP_TX_OFF          = 0x0
+	HWTSTAMP_TX_ON           = 0x1
+	HWTSTAMP_TX_ONESTEP_SYNC = 0x2
+)
+
 type (
 	HIDRawReportDescriptor struct {
 		Size  uint32


### PR DESCRIPTION
Add the ioctls to get/set the hardware timestamping configuration
(SIOCSHWTSTAMP and SIOCGHWTSTAMP) along with relevant symbols.

The usage is described in
https://www.kernel.org/doc/Documentation/networking/timestamping.txt