### PR TITLE
unix: add PTP_PF_* constants on Linux

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -4148,6 +4148,13 @@ type (
 	PtpSysOffsetPrecise C.struct_ptp_sys_offset_precise
 )
 
+const (
+	PTP_PF_NONE    = C.PTP_PF_NONE
+	PTP_PF_EXTTS   = C.PTP_PF_EXTTS
+	PTP_PF_PEROUT  = C.PTP_PF_PEROUT
+	PTP_PF_PHYSYNC = C.PTP_PF_PHYSYNC
+)
+
 type (
 	HIDRawReportDescriptor C.struct_hidraw_report_descriptor
 	HIDRawDevInfo          C.struct_hidraw_devinfo

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -4203,6 +4203,13 @@ type (
 	}
 )
 
+const (
+	PTP_PF_NONE    = 0x0
+	PTP_PF_EXTTS   = 0x1
+	PTP_PF_PEROUT  = 0x2
+	PTP_PF_PHYSYNC = 0x3
+)
+
 type (
 	HIDRawReportDescriptor struct {
 		Size  uint32


### PR DESCRIPTION
These represent valid values for PtpPinDesc.Func.
They are defined as enum, thus not emitted from mkerrors.sh.