### PR TITLE
cpu: Correct the description of an ARM64 flag in cpu.go

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -100,7 +100,7 @@ var ARM64 struct {
 	HasSHA3     bool // SHA3 hardware implementation
 	HasSM3      bool // SM3 hardware implementation
 	HasSM4      bool // SM4 hardware implementation
-	HasASIMDDP  bool // Advanced SIMD double precision instruction set
+	HasASIMDDP  bool // Advanced SIMD dot product instruction set
 	HasSHA512   bool // SHA512 hardware implementation
 	HasSVE      bool // Scalable Vector Extensions
 	HasSVE2     bool // Scalable Vector Extensions 2


### PR DESCRIPTION
The comment describing HasASIMDDP says it's for "double precision", but actually it means "dot product", which is a very different meaning and is used by AI CNNs and many other important applications.