### PR TITLE
windows: update NewLazyDLL, LoadDLL docs to point to NewLazySystemDLL

### DIFF
--- a/windows/dll_windows.go
+++ b/windows/dll_windows.go
@@ -43,8 +43,8 @@ type DLL struct {
 // LoadDLL loads DLL file into memory.
 //
 // Warning: using LoadDLL without an absolute path name is subject to
-// DLL preloading attacks. To safely load a system DLL, use LazyDLL
-// with System set to true, or use LoadLibraryEx directly.
+// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL],
+// [LazyDLL] with System set to true, or use [LoadLibraryEx] directly.
 func LoadDLL(name string) (dll *DLL, err error) {
 	namep, err := UTF16PtrFromString(name)
 	if err != nil {
@@ -271,6 +271,9 @@ func (d *LazyDLL) NewProc(name string) *LazyProc {
 }
 
 // NewLazyDLL creates new LazyDLL associated with DLL file.
+//
+// Warning: using NewLazyDLL without an absolute path name is subject to
+// DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL].
 func NewLazyDLL(name string) *LazyDLL {
 	return &LazyDLL{Name: name}
 }

--- a/windows/dll_windows.go
+++ b/windows/dll_windows.go
@@ -44,7 +44,7 @@ type DLL struct {
 //
 // Warning: using LoadDLL without an absolute path name is subject to
 // DLL preloading attacks. To safely load a system DLL, use [NewLazySystemDLL],
-// [LazyDLL] with System set to true, or use [LoadLibraryEx] directly.
+// or use [LoadLibraryEx] directly.
 func LoadDLL(name string) (dll *DLL, err error) {
 	namep, err := UTF16PtrFromString(name)
 	if err != nil {


### PR DESCRIPTION
Point users to the NewLazySystemDLL utility that was added in CL 21592.