### PR TITLE
windows: remove unused errString type

### DIFF
--- a/windows/dll_windows.go
+++ b/windows/dll_windows.go
@@ -410,7 +410,3 @@ func loadLibraryEx(name string, system bool) (*DLL, error) {
 	}
 	return &DLL{Name: name, Handle: h}, nil
 }
-
-type errString string
-
-func (s errString) Error() string { return string(s) }


### PR DESCRIPTION
It's no longer used since CL 165759.