### PR TITLE
cpu: add support for AVX-VNNI and IFMA detection

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -72,6 +72,9 @@ var X86 struct {
 	HasSSSE3            bool // Supplemental streaming SIMD extension 3
 	HasSSE41            bool // Streaming SIMD extension 4 and 4.1
 	HasSSE42            bool // Streaming SIMD extension 4 and 4.2
+	HasAVXIFMA          bool // Advanced vector extension Integer Fused Multiply Add
+	HasAVXVNNI          bool // Advanced vector extension Vector Neural Network Instructions
+	HasAVXVNNIInt8      bool // Advanced vector extension Vector Neural Network Int8 instructions
 	_                   CacheLinePad
 }
 

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -41,6 +41,40 @@ func TestAVX512HasAVX2AndAVX(t *testing.T) {
 	}
 }
 
+func TestAVX512BF16HasAVX512(t *testing.T) {
+	if runtime.GOARCH == "amd64" {
+		if cpu.X86.HasAVX512BF16 && !cpu.X86.HasAVX512 {
+			t.Fatal("HasAVX512 expected true, got false")
+		}
+	}
+}
+
+func TestAVXVNNIHasAVX(t *testing.T) {
+	if cpu.X86.HasAVXVNNI && !cpu.X86.HasAVX {
+		t.Fatal("HasAVX expected true, got false")
+	}
+}
+
+func TestAVXIFMAHasAVXVNNIAndAVX(t *testing.T) {
+	if cpu.X86.HasAVXIFMA && !cpu.X86.HasAVX {
+		t.Fatal("HasAVX expected true, got false")
+	}
+
+	if cpu.X86.HasAVXIFMA && !cpu.X86.HasAVXVNNI {
+		t.Fatal("HasAVXVNNI expected true, got false")
+	}
+}
+
+func TestAVXVNNIInt8HasAVXVNNIAndAVX(t *testing.T) {
+	if cpu.X86.HasAVXVNNIInt8 && !cpu.X86.HasAVXVNNI {
+		t.Fatal("HasAVXVNNI expected true, got false")
+	}
+
+	if cpu.X86.HasAVXVNNIInt8 && !cpu.X86.HasAVX {
+		t.Fatal("HasAVX expected true, got false")
+	}
+}
+
 func TestARM64minimalFeatures(t *testing.T) {
 	if runtime.GOARCH != "arm64" || runtime.GOOS == "ios" {
 		return


### PR DESCRIPTION
Added detection for x86 AVX-VNNI (VEX-coded Vector Neural Network 
Instructions) and AVX-IFMA (VEX-coded Integer Fused Multiply Add), 
including both the base VNNI set and the Int8 extention.

Fixes golang/go#71142