### PR TITLE
unix: update Linux kernel to 6.14

### DIFF
--- a/unix/linux/Dockerfile
+++ b/unix/linux/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y  --no-install-recommends \
 # Get the git sources. If not cached, this takes O(5 minutes).
 WORKDIR /git
 RUN git config --global advice.detachedHead false
-# Linux Kernel: Released 20 Jan 2025
-RUN git clone --branch v6.13 --depth 1 https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux
+# Linux Kernel: Released 24 Mar 2025
+RUN git clone --branch v6.14 --depth 1 https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux
 # GNU C library: Released 29 Jan 2025
 RUN git clone --branch release/2.41/master --depth 1 https://sourceware.org/git/glibc.git
 


### PR DESCRIPTION
No new syscalls or constants in this release, just bumping the version number.