### PR TITLE
windows/registry: correct KeyInfo.ModTime calculation

### DIFF
--- a/windows/registry/export_test.go
+++ b/windows/registry/export_test.go
@@ -9,3 +9,7 @@ package registry
 func (k Key) SetValue(name string, valtype uint32, data []byte) error {
 	return k.setValue(name, valtype, data)
 }
+
+func (ki *KeyInfo) ModTimeZero() bool {
+	return ki.modTimeZero()
+}

--- a/windows/registry/key.go
+++ b/windows/registry/key.go
@@ -198,7 +198,20 @@ type KeyInfo struct {
 
 // ModTime returns the key's last write time.
 func (ki *KeyInfo) ModTime() time.Time {
-	return time.Unix(0, ki.lastWriteTime.Nanoseconds())
+	lastHigh, lastLow := ki.lastWriteTime.HighDateTime, ki.lastWriteTime.LowDateTime
+	// 100-nanosecond intervals since January 1, 1601
+	hsec := uint64(lastHigh)<<32 + uint64(lastLow)
+	// Convert _before_ gauging; the nanosecond difference between Epoch (00:00:00
+	// UTC, January 1, 1970) and Filetime's zero offset (January 1, 1601) is out
+	// of bounds for int64: -11644473600*1e7*1e2 < math.MinInt64
+	sec := int64(hsec/1e7) - 11644473600
+	nsec := int64(hsec%1e7) * 100
+	return time.Unix(sec, nsec)
+}
+
+// modTimeZero reports whether the key's last write time is zero.
+func (ki *KeyInfo) modTimeZero() bool {
+	return ki.lastWriteTime.LowDateTime == 0 && ki.lastWriteTime.HighDateTime == 0
 }
 
 // Stat retrieves information about the open key k.


### PR DESCRIPTION
Filetime.Nanoseconds() has a major drawback: the returned int64 is too small to
represent Filetime's zero value (January 1, 1601, [1]) in terms of nanoseconds
since Epoch (00:00:00 UTC, January 1, 1970); MinInt64 [2] only dates back to
year 1677.

This has real-life implications, e.g., some Windows sub systems (Perflib, to
    name one) create registry keys with the last write time property set to
zero (see note below). In this case, ModTime() reports an underflow-affected
value of 2185-07-22T00:34:33.709551+01:00.

This commit drops usage of Nanoseconds() in favor of a conversion that converts
first to seconds and nanoseconds before gauging thus is capable to cover the
full range of Filetime values.

A note on last write time values: `lastWriteTime` is not exposed in the UI
(say, `regedit`) or in PowerShell (`Get-ItemProperty`), you need to query
`RegQueryInfoKeyA` [3] explicitly in some way [4] or another [5]. The source of
the latter is offline by now but can be found elsewhere [6] and provides a
quick way to show the value.

[1] https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
[2] https://pkg.go.dev/math#pkg-constants
[3] https://learn.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regqueryinfokeya?redirectedfrom=MSDN
[4] https://learn.microsoft.com/en-us/windows/win32/sysinfo/retrieving-the-last-write-time
[5] https://learn-powershell.net/2014/12/18/retrieving-a-registry-key-lastwritetime-using-powershell/
[6] https://github.com/wxrdnx/GetRegistryKeyLastWriteTimeAndClassName

Fixes golang/go#74335.