### PR TITLE
unix: the error should not be overridden by anyToSockaddr

### DIFF
--- a/unix/syscall_unix.go
+++ b/unix/syscall_unix.go
@@ -369,7 +369,7 @@ func Recvmsg(fd int, p, oob []byte, flags int) (n, oobn int, recvflags int, from
 	var rsa RawSockaddrAny
 	n, oobn, recvflags, err = recvmsgRaw(fd, iov[:], oob, flags, &rsa)
 	// source address is only specified if the socket is unconnected
-	if rsa.Addr.Family != AF_UNSPEC {
+	if err == nil && rsa.Addr.Family != AF_UNSPEC {
 		from, err = anyToSockaddr(fd, &rsa)
 	}
 	return


### PR DESCRIPTION
The error should not be overridden by anyToSockaddr. Otherwise, the
length of the data will return as -1

Upon successful completion, recvmsg() shall return the length of the
message in bytes. If no messages are available to be received and
the peer has performed an orderly shutdown, recvmsg() shall return
0. Otherwise, -1 shall be returned and  
https://man7.org/linux/man-pages/man3/errno.3.html set to indicate 
the error.