### PR TITLE
unix: fix //sys decl after CL 548795

### DIFF
--- a/unix/syscall_darwin.go
+++ b/unix/syscall_darwin.go
@@ -602,7 +602,6 @@ func Connectx(fd int, srcIf uint32, srcAddr, dstAddr Sockaddr, associd SaeAssocI
 	return
 }
 
-// sys	connectx(fd int, endpoints *SaEndpoints, associd SaeAssocID, flags uint32, iov []Iovec, n *uintptr, connid *SaeConnID) (err error)
 const minIovec = 8
 
 func Readv(fd int, iovs [][]byte) (n int, err error) {
@@ -746,6 +745,7 @@ func darwinKernelVersionMin(maj, min, patch int) bool {
 	return actualMaj > maj || actualMaj == maj && (actualMin > min || actualMin == min && actualPatch >= patch)
 }
 
+//sys	connectx(fd int, endpoints *SaEndpoints, associd SaeAssocID, flags uint32, iov []Iovec, n *uintptr, connid *SaeConnID) (err error)
 //sys	sendfile(infd int, outfd int, offset int64, len *int64, hdtr unsafe.Pointer, flags int) (err error)
 
 //sys	shmat(id int, addr uintptr, flag int) (ret uintptr, err error)


### PR DESCRIPTION
CL 548795 mistakenly changed one of the //sys declaration to "// sys"
while resolving a merge conflict.

For golang/go#64710