### PR TITLE
unix: add missing nft conntrack constants

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -2384,6 +2384,11 @@ const (
 	NFT_CT_AVGPKT                     = C.NFT_CT_AVGPKT
 	NFT_CT_ZONE                       = C.NFT_CT_ZONE
 	NFT_CT_EVENTMASK                  = C.NFT_CT_EVENTMASK
+	NFT_CT_SRC_IP                     = C.NFT_CT_SRC_IP
+	NFT_CT_DST_IP                     = C.NFT_CT_DST_IP
+	NFT_CT_SRC_IP6                    = C.NFT_CT_SRC_IP6
+	NFT_CT_DST_IP6                    = C.NFT_CT_DST_IP6
+	NFT_CT_ID                         = C.NFT_CT_ID
 	NFTA_CT_UNSPEC                    = C.NFTA_CT_UNSPEC
 	NFTA_CT_DREG                      = C.NFTA_CT_DREG
 	NFTA_CT_KEY                       = C.NFTA_CT_KEY

--- a/unix/ztypes_linux.go
+++ b/unix/ztypes_linux.go
@@ -2317,6 +2317,11 @@ const (
 	NFT_CT_AVGPKT                     = 0x10
 	NFT_CT_ZONE                       = 0x11
 	NFT_CT_EVENTMASK                  = 0x12
+	NFT_CT_SRC_IP                     = 0x13
+	NFT_CT_DST_IP                     = 0x14
+	NFT_CT_SRC_IP6                    = 0x15
+	NFT_CT_DST_IP6                    = 0x16
+	NFT_CT_ID                         = 0x17
 	NFTA_CT_UNSPEC                    = 0x0
 	NFTA_CT_DREG                      = 0x1
 	NFTA_CT_KEY                       = 0x2


### PR DESCRIPTION
The following constants were missing for nft conntrack:

- `NFT_CT_SRC_IP`
- `NFT_CT_DST_IP`
- `NFT_CT_SRC_IP6`
- `NFT_CT_DST_IP6`
- `NFT_CT_ID`

https://git.netfilter.org/libnftnl/tree/include/linux/netfilter/nf_tables.h?id=7a7722ee336fac14690851f6c84965582a741601#n1173