### PR TITLE
windows: add FILE_ZERO_DATA_INFORMATION

### DIFF
--- a/windows/types_windows.go
+++ b/windows/types_windows.go
@@ -1976,6 +1976,12 @@ const (
 	SYMBOLIC_LINK_FLAG_DIRECTORY     = 0x1
 )
 
+// FILE_ZERO_DATA_INFORMATION from winioctl.h
+type FileZeroDataInformation struct {
+	FileOffset      int64
+	BeyondFinalZero int64
+}
+
 const (
 	ComputerNameNetBIOS                   = 0
 	ComputerNameDnsHostname               = 1


### PR DESCRIPTION
This is needed for invoking windows.DeviceIoControl with
windows.FSCTL_SET_ZERO_DATA.