### PR TITLE
unix: switch (*CPUSet).Zero to clear builtin

### DIFF
--- a/unix/affinity_linux.go
+++ b/unix/affinity_linux.go
@@ -38,9 +38,7 @@ func SchedSetaffinity(pid int, set *CPUSet) error {
 
 // Zero clears the set s, so that it contains no CPUs.
 func (s *CPUSet) Zero() {
-	for i := range s {
-		s[i] = 0
-	}
+	clear(s[:])
 }
 
 func cpuBitsIndex(cpu int) int {


### PR DESCRIPTION
clear was added to Go 1.21 and is better than the manual loop approach.