### PR TITLE
plan9: fix Exit build failure by using syscall.Exit directly

### DIFF
--- a/plan9/asm_plan9_386.s
+++ b/plan9/asm_plan9_386.s
@@ -26,5 +26,3 @@ TEXT ·RawSyscall6(SB),NOSPLIT,$0-40
 TEXT ·seek(SB),NOSPLIT,$0-36
 	JMP	syscall·seek(SB)
 
-TEXT ·exit(SB),NOSPLIT,$4-4
-	JMP	syscall·exit(SB)

--- a/plan9/asm_plan9_amd64.s
+++ b/plan9/asm_plan9_amd64.s
@@ -26,5 +26,3 @@ TEXT	·RawSyscall6(SB),NOSPLIT,$0-80
 TEXT ·seek(SB),NOSPLIT,$0-56
 	JMP	syscall·seek(SB)
 
-TEXT ·exit(SB),NOSPLIT,$8-8
-	JMP	syscall·exit(SB)

--- a/plan9/syscall_plan9.go
+++ b/plan9/syscall_plan9.go
@@ -61,10 +61,8 @@ func errstr() string {
 	return cstring(buf[:])
 }
 
-// Implemented in assembly to import from runtime.
-func exit(code int)
-
-func Exit(code int) { exit(code) }
+// Exit calls the runtime-provided syscall.Exit.
+func Exit(code int) { syscall.Exit(code) }
 
 func readnum(path string) (uint, error) {
 	var b [12]byte


### PR DESCRIPTION
## Summary

Fixes golang/go#78506.

## Problem

On Plan 9 with GOARCH=amd64, building the `golang.org/x/sys/plan9` package fails:

```
$ GOARCH=amd64 GOOS=plan9 go build
# test
golang.org/x/sys/plan9.exit: relocation target syscall.exit not defined
```

The `plan9.Exit` function called an assembly stub `exit` which jumped to
`syscall.exit`. However, `syscall.exit` does not exist on Plan 9 — `Exit` is
provided by the Go runtime directly.

## Solution

Replace the assembly stub with a direct call to `syscall.Exit`, which is the
proper way to exit a process on Plan 9. This matches how other stdlib packages
handle `Exit`.

## Changes

- `plan9/syscall_plan9.go`: Replace `func exit(code int)` external declaration and assembly call with direct `syscall.Exit` call
- `plan9/asm_plan9_amd64.s`: Remove the `exit` assembly stub
- `plan9/asm_plan9_386.s`: Remove the `exit` assembly stub