### PR TITLE
windows: avoid length overflow in NewNTString

### DIFF
--- a/windows/syscall_windows.go
+++ b/windows/syscall_windows.go
@@ -1727,13 +1727,19 @@ func (s *NTUnicodeString) String() string {
 // do not use NTString, and instead UTF16PtrFromString should be used for
 // the more common *uint16 string type.
 func NewNTString(s string) (*NTString, error) {
-	var nts NTString
-	s8, err := BytePtrFromString(s)
+	if len(s) > (1<<16)-2 {
+		return nil, syscall.EINVAL
+	}
+	s8, err := ByteSliceFromString(s)
 	if err != nil {
 		return nil, err
 	}
-	RtlInitString(&nts, s8)
-	return &nts, nil
+	n := len(s8)
+	return &NTString{
+		Length:        uint16(n) - 1, // subtract 1 byte for the NULL terminator
+		MaximumLength: uint16(n),
+		Buffer:        &s8[0],
+	}, nil
 }
 
 // Slice returns a byte slice that aliases the data in the NTString.

--- a/windows/syscall_windows_test.go
+++ b/windows/syscall_windows_test.go
@@ -1516,6 +1516,40 @@ func TestRoundtripNTUnicodeString(t *testing.T) {
 	}
 }
 
+func TestRoundtripNTString(t *testing.T) {
+	// NTString maximum string length must fit in a uint16, less for terminal NUL.
+	maxString := strings.Repeat("*", math.MaxUint16-1)
+	for _, test := range []struct {
+		s       string
+		wantErr bool
+	}{{
+		s: "",
+	}, {
+		s: "hello",
+	}, {
+		s: maxString,
+	}, {
+		s:       maxString + "*",
+		wantErr: true,
+	}, {
+		s:       "a\x00a",
+		wantErr: true,
+	}} {
+		nts, err := windows.NewNTString(test.s)
+		if (err != nil) != test.wantErr {
+			t.Errorf("NewNTString(%q): %v, wantErr:%v", test.s, err, test.wantErr)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		s2 := nts.String()
+		if test.s != s2 {
+			t.Errorf("round trip of %q = %q, wanted original", test.s, s2)
+		}
+	}
+}
+
 func TestIsProcessorFeaturePresent(t *testing.T) {
 	// according to
 	// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent


### PR DESCRIPTION
NewNTString currently delegates length initialization to RtlInitString, which cannot accurately represent source strings longer than MAXUSHORT-1 bytes. Reject strings that cannot fit in NTString's uint16 length fields and construct the NTString directly, matching NewNTUnicodeString.

This also adds a boundary round-trip test for NTString.

Verification:
- env GOOS=windows GOARCH=386 CGO_ENABLED=0 GOCACHE=/tmp/gocache GOMODCACHE=/tmp/gomod go test -c -o /tmp/sys-windows-386.test ./windows
- env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOCACHE=/tmp/gocache GOMODCACHE=/tmp/gomod go test -c -o /tmp/sys-windows-amd64.test ./windows
- env WINEPREFIX=/home/bg0d/Documents/google_bug/copy_sys/golang_sys/sys/.wine-test wine /tmp/sys-windows-386.test -test.run TestRoundtripNTString -test.v

Updates golang/go#80103