### PR TITLE
sys/unix: add Mmsghdr for linux

### DIFF
--- a/unix/linux/types.go
+++ b/unix/linux/types.go
@@ -775,6 +775,8 @@ type PacketMreq C.struct_packet_mreq
 
 type Msghdr C.struct_msghdr
 
+type Mmsghdr C.struct_mmsghdr
+
 type Cmsghdr C.struct_cmsghdr
 
 type Inet4Pktinfo C.struct_in_pktinfo
@@ -829,6 +831,7 @@ const (
 	SizeofIPv6Mreq          = C.sizeof_struct_ipv6_mreq
 	SizeofPacketMreq        = C.sizeof_struct_packet_mreq
 	SizeofMsghdr            = C.sizeof_struct_msghdr
+	SizeofMmsghdr           = C.sizeof_struct_mmsghdr
 	SizeofCmsghdr           = C.sizeof_struct_cmsghdr
 	SizeofInet4Pktinfo      = C.sizeof_struct_in_pktinfo
 	SizeofInet6Pktinfo      = C.sizeof_struct_in6_pktinfo

--- a/unix/ztypes_linux_386.go
+++ b/unix/ztypes_linux_386.go
@@ -163,6 +163,11 @@ type Msghdr struct {
 	Flags      int32
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+}
+
 type Cmsghdr struct {
 	Len   uint32
 	Level int32
@@ -178,6 +183,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x58
 	SizeofIovec           = 0x8
 	SizeofMsghdr          = 0x1c
+	SizeofMmsghdr         = 0x20
 	SizeofCmsghdr         = 0xc
 )
 

--- a/unix/ztypes_linux_amd64.go
+++ b/unix/ztypes_linux_amd64.go
@@ -166,6 +166,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -181,6 +187,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_arm.go
+++ b/unix/ztypes_linux_arm.go
@@ -169,6 +169,11 @@ type Msghdr struct {
 	Flags      int32
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+}
+
 type Cmsghdr struct {
 	Len   uint32
 	Level int32
@@ -184,6 +189,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x58
 	SizeofIovec           = 0x8
 	SizeofMsghdr          = 0x1c
+	SizeofMmsghdr         = 0x20
 	SizeofCmsghdr         = 0xc
 )
 

--- a/unix/ztypes_linux_arm64.go
+++ b/unix/ztypes_linux_arm64.go
@@ -167,6 +167,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -182,6 +188,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_loong64.go
+++ b/unix/ztypes_linux_loong64.go
@@ -167,6 +167,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -182,6 +188,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_mips.go
+++ b/unix/ztypes_linux_mips.go
@@ -168,6 +168,11 @@ type Msghdr struct {
 	Flags      int32
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+}
+
 type Cmsghdr struct {
 	Len   uint32
 	Level int32
@@ -183,6 +188,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x58
 	SizeofIovec           = 0x8
 	SizeofMsghdr          = 0x1c
+	SizeofMmsghdr         = 0x20
 	SizeofCmsghdr         = 0xc
 )
 

--- a/unix/ztypes_linux_mips64.go
+++ b/unix/ztypes_linux_mips64.go
@@ -167,6 +167,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -182,6 +188,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_mips64le.go
+++ b/unix/ztypes_linux_mips64le.go
@@ -167,6 +167,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -182,6 +188,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_mipsle.go
+++ b/unix/ztypes_linux_mipsle.go
@@ -168,6 +168,11 @@ type Msghdr struct {
 	Flags      int32
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+}
+
 type Cmsghdr struct {
 	Len   uint32
 	Level int32
@@ -183,6 +188,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x58
 	SizeofIovec           = 0x8
 	SizeofMsghdr          = 0x1c
+	SizeofMmsghdr         = 0x20
 	SizeofCmsghdr         = 0xc
 )
 

--- a/unix/ztypes_linux_ppc.go
+++ b/unix/ztypes_linux_ppc.go
@@ -169,6 +169,11 @@ type Msghdr struct {
 	Flags      int32
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+}
+
 type Cmsghdr struct {
 	Len   uint32
 	Level int32
@@ -184,6 +189,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x58
 	SizeofIovec           = 0x8
 	SizeofMsghdr          = 0x1c
+	SizeofMmsghdr         = 0x20
 	SizeofCmsghdr         = 0xc
 )
 

--- a/unix/ztypes_linux_ppc64.go
+++ b/unix/ztypes_linux_ppc64.go
@@ -168,6 +168,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -183,6 +189,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_ppc64le.go
+++ b/unix/ztypes_linux_ppc64le.go
@@ -168,6 +168,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -183,6 +189,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_riscv64.go
+++ b/unix/ztypes_linux_riscv64.go
@@ -167,6 +167,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -182,6 +188,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_s390x.go
+++ b/unix/ztypes_linux_s390x.go
@@ -166,6 +166,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -181,6 +187,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 

--- a/unix/ztypes_linux_sparc64.go
+++ b/unix/ztypes_linux_sparc64.go
@@ -170,6 +170,12 @@ type Msghdr struct {
 	_          [4]byte
 }
 
+type Mmsghdr struct {
+	Hdr Msghdr
+	Len uint32
+	_   [4]byte
+}
+
 type Cmsghdr struct {
 	Len   uint64
 	Level int32
@@ -185,6 +191,7 @@ const (
 	SizeofSockaddrNFCLLCP = 0x60
 	SizeofIovec           = 0x10
 	SizeofMsghdr          = 0x38
+	SizeofMmsghdr         = 0x40
 	SizeofCmsghdr         = 0x10
 )
 


### PR DESCRIPTION
Expose struct mmsghdr as Mmsghdr, along with SizeofMmsghdr, so
callers can build recvmmsg(2) without redefining the types per
architecture.

This is split out from the Recvmmsg wrapper proposed in
golang/go#80434, since that API is still under discussion and this
change itself is non-controversial.

Updates golang/go#80434
