### PR TITLE
unix: keep generated types compilable with current cgo

### DIFF
--- a/unix/mkpost.go
+++ b/unix/mkpost.go
@@ -73,6 +73,13 @@ func main() {
 	}
 
 	if goos == "freebsd" {
+		// Where struct fp_extended_precision is not declared, cgo -godefs
+		// now renders FpExtendedPrecision as _cgopackage.Incomplete, which
+		// does not compile. The files generated for those platforms carry
+		// an empty struct, so keep producing that.
+		incompleteFpExtended := regexp.MustCompile(`type FpExtendedPrecision _cgopackage\.Incomplete`)
+		b = incompleteFpExtended.ReplaceAll(b, []byte("type FpExtendedPrecision struct{}"))
+
 		// Inside PtraceLwpInfoStruct replace __Siginfo with __PtraceSiginfo,
 		// Create __PtraceSiginfo as a copy of __Siginfo where every *byte instance is replaced by uintptr
 		ptraceLwpInfoStruct := regexp.MustCompile(`(?s:type PtraceLwpInfoStruct struct \{.*?\})`)


### PR DESCRIPTION
I hit this while regenerating ztypes for a platform that is not in the tree
yet, but it is not specific to that: any regeneration with a current
toolchain runs into it.

Where `struct fp_extended_precision` is not declared, `cgo -godefs` now
renders `FpExtendedPrecision` as `_cgopackage.Incomplete`, and the result
does not compile. The committed files for those platforms carry an empty
struct, so this keeps mkpost producing what is already there.

freebsd/arm is unaffected: the C type is declared there, so cgo never emits
`Incomplete` for it.
