### PR TITLE
cpu: add basic support for GOARCH=sparc64

### DIFF
--- a/cpu/cpu_sparc64.go
+++ b/cpu/cpu_sparc64.go
@@ -1,0 +1,12 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build sparc64
+
+package cpu
+
+// The L1 line is 32 bytes; false sharing is governed by the 64-byte L2 line.
+const cacheLineSize = 64
+
+func initOptions() {}


### PR DESCRIPTION
cpu.go uses cacheLineSize for CacheLinePad and calls initOptions, both
of which are supplied per architecture, so the package does not build on
sparc64. This adds those two for it.

Updates golang/go#55000
